### PR TITLE
Fix MQTT loop thread crash. #20

### DIFF
--- a/pi_mqtt_gpio/server.py
+++ b/pi_mqtt_gpio/server.py
@@ -77,22 +77,6 @@ class ConfigValidator(cerberus.Validator):
         return str(value)
 
 
-def on_disconnect(client, userdata, rc):
-    """
-    Called when MQTT client disconnects. Attempts to reconnect indefinitely
-    if disconnection was unintentional.
-    :param client: MQTT client instance
-    :param userdata: Any user data set in client
-    :param rc: The disconnection result (0 is intentional disconnect)
-    :return: None
-    :rtype: NoneType
-    """
-    _LOG.warning("Disconnected from MQTT server with code: %s" % rc)
-    while rc != 0:
-        sleep(RECONNECT_DELAY_SECS)
-        rc = client.reconnect()
-
-
 def on_log(client, userdata, level, buf):
     """
     Called when MQTT client wishes to log something.
@@ -364,7 +348,6 @@ def init_mqtt(config, digital_outputs):
         except Exception:
             _LOG.exception("Exception while handling received MQTT message:")
 
-    client.on_disconnect = on_disconnect
     client.on_connect = on_conn
     client.on_message = on_msg
     client.on_log = on_log


### PR DESCRIPTION
paho-mqtt's loop thread handles reconnecting, but if there is an on_disconnect callback which raises an exception, the thread simply gets stuck. In order to have the thread reconnect automatically, remove the callback which could raise an exception.

Tested on a raspberry pi with

paho-mqtt (1.3.1)
pi-mqtt-gpio (0.1.1)

My test involved adding a REJECT iptables rule to make the connection fail and it was always re-established after a missed PINGREQ.

Fixes #20 