### PR TITLE
Added tested "OUT" orange pi support module

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -9,6 +9,9 @@ gpio_modules:
   - name: raspberrypi
     module: raspberrypi
 
+  - name: orangepi
+    module: orangepi
+
   - name: pcf8574
     module: pcf8574
     i2c_bus_num: 1

--- a/pi_mqtt_gpio/modules/orangepi.py
+++ b/pi_mqtt_gpio/modules/orangepi.py
@@ -1,0 +1,53 @@
+from pi_mqtt_gpio.modules import GenericGPIO, PinDirection, PinPullup
+
+
+REQUIREMENTS = ("OPi.GPIO",)
+
+DIRECTIONS = None
+PULLUPS = None
+
+
+class GPIO(GenericGPIO):
+    """
+    Implementation of GPIO class for Raspberry Pi native GPIO.
+    """
+    def __init__(self, config):
+        global DIRECTIONS, PULLUPS
+        import OPi.GPIO as gpio
+        self.io = gpio
+        DIRECTIONS = {
+            PinDirection.INPUT: gpio.IN,
+            PinDirection.OUTPUT: gpio.OUT
+        }
+
+        PULLUPS = {
+            PinPullup.OFF: 0,
+            PinPullup.UP: 0,
+            PinPullup.DOWN: 0, #gpio.PUD_DOWN
+        }
+
+        gpio.setmode(gpio.BOARD)
+
+    def setup_pin(self, pin, direction, pullup, pin_config):
+        direction = DIRECTIONS[direction]
+
+        if pullup is None:
+            pullup = PULLUPS[PinPullup.OFF]
+        else:
+            pullup = PULLUPS[pullup]
+
+        initial = {
+            None: -1,
+            "low": 0,
+            "high": 1
+        }[pin_config.get("initial")]
+        self.io.setup(pin, direction, pull_up_down=pullup, initial=initial)
+
+    def set_pin(self, pin, value):
+        self.io.output(pin, value)
+
+    def get_pin(self, pin):
+        return self.io.input(pin)
+
+    def cleanup(self):
+        self.io.cleanup()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ paho-mqtt
 PyYAML
 enum34
 cerberus
-
+OPi.GPIO


### PR DESCRIPTION
Hi, thanks for your GREAT project, it perfectly fits my home automation project where I have home-assistant+mosquitto server and several network connected orange pi slaves.

I managed to successfully integrate your module by copying raspberry.py module and changing mode to GPIO.BOARD

I am willing to continue contributing to this project and add support for orangepi "input" devices. 
Let me know if that matches your project goals and python coding standards.

Thanks
- Oleksandr 