### PR TITLE
Orangepi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ GPIO Modules
 ------------
 
 - Raspberry Pi GPIO (`raspberrypi`)
+- Orange Pi GPIO (`orangepi`)
 - PCF8574 IO chip (`pcf8574`)
 - PiFaceDigital 2 IO board (`piface2`)
 - Beaglebone GPIO (`beaglebone`)
@@ -151,6 +152,17 @@ sensor_inputs:
     
 ```
 
+### OrangePi boards
+
+You need to specify what OrangePi board you use
+
+```yaml
+gpio_modules:
+  - name: orangepi
+    module: orangepi
+    board: zero # Supported: ZERO, R1, ZEROPLUS, ZEROPLUS2H5, ZEROPLUS2H3, PCPCPLUS, ONE, LITE, PLUS2E, PC2, PRIME
+```
+
 #### SSL/TLS
 
 You may want to connect to a remote server, in which case it's a good idea to use an encrypted connection. If the server supports this, then you can supply the relevant config values for the [tls_set()](https://github.com/eclipse/paho.mqtt.python#tls_set) command.
@@ -214,6 +226,10 @@ gpio_modules:
     module: pcf8574
     i2c_bus_num: 1
     chip_addr: 0x20
+
+  - name: orangepi
+    module: orangepi
+    board: r1
 
 digital_inputs:
   - name: button

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ gpio_modules:
   - name: orangepi
     module: orangepi
     board: zero # Supported: ZERO, R1, ZEROPLUS, ZEROPLUS2H5, ZEROPLUS2H3, PCPCPLUS, ONE, LITE, PLUS2E, PC2, PRIME
+    mode: board
 ```
 
 #### SSL/TLS

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ gpio_modules:
   - name: orangepi
     module: orangepi
     board: r1
+    mode: board
 
 digital_inputs:
   - name: button

--- a/config.example.yml
+++ b/config.example.yml
@@ -21,6 +21,7 @@ gpio_modules:
   - name: orangepi
     module: orangepi
     board: zero
+    mode: board
 
 sensor_modules:
   - name: lm75

--- a/config.example.yml
+++ b/config.example.yml
@@ -18,6 +18,10 @@ gpio_modules:
     module: stdio
     cleanup: no
 
+  - name: orangepi
+    module: orangepi
+    board: zero
+
 sensor_modules:
   - name: lm75
     module: lm75

--- a/pi_mqtt_gpio/modules/orangepi.py
+++ b/pi_mqtt_gpio/modules/orangepi.py
@@ -15,8 +15,9 @@ CONFIG_SCHEMA = {
     },
     "mode": {
         "type": "string",
-        "required": False,
+        "required": True,
         "empty": False,
+        "default": "bcm",
         "allowed": ALLOWED_MODES + list(map(str.upper, ALLOWED_MODES))
     }
 }
@@ -44,7 +45,7 @@ class GPIO(GenericGPIO):
         }
 
         board = config["board"].upper()
-        mode = config.get("mode", "bcm").upper()
+        mode = config["mode"].upper()
         if not hasattr(gpio, board):
             raise AssertionError("%s board not found" % board)
         gpio.setboard(getattr(gpio, board))

--- a/pi_mqtt_gpio/modules/orangepi.py
+++ b/pi_mqtt_gpio/modules/orangepi.py
@@ -1,7 +1,18 @@
 from pi_mqtt_gpio.modules import GenericGPIO, PinDirection, PinPullup
 
-
+ALLOWED_BOARDS = [
+    'zero', 'r1', 'zeroplus', 'zeroplus2h5', 'zeroplus2h3',
+    'pcpcplus', 'one', 'lite', 'plus2e', 'pc2', 'prime'
+]
 REQUIREMENTS = ("OrangePi.GPIO",)
+CONFIG_SCHEMA = {
+    "board": {
+        "type": "string",
+        "required": True,
+        "empty": False,
+        "allowed": ALLOWED_BOARDS + list(map(str.upper, ALLOWED_BOARDS))
+    }
+}
 
 DIRECTIONS = None
 PULLUPS = None
@@ -9,7 +20,7 @@ PULLUPS = None
 
 class GPIO(GenericGPIO):
     """
-    Implementation of GPIO class for Raspberry Pi native GPIO.
+    Implementation of GPIO class for Orange Pi native GPIO.
     """
 
     def __init__(self, config):

--- a/pi_mqtt_gpio/modules/orangepi.py
+++ b/pi_mqtt_gpio/modules/orangepi.py
@@ -1,0 +1,52 @@
+from pi_mqtt_gpio.modules import GenericGPIO, PinDirection, PinPullup
+
+
+REQUIREMENTS = ("OrangePi.GPIO",)
+
+DIRECTIONS = None
+PULLUPS = None
+
+
+class GPIO(GenericGPIO):
+    """
+    Implementation of GPIO class for Raspberry Pi native GPIO.
+    """
+
+    def __init__(self, config):
+        global DIRECTIONS, PULLUPS
+        import OPi.GPIO as gpio
+
+        self.io = gpio
+        DIRECTIONS = {PinDirection.INPUT: gpio.IN, PinDirection.OUTPUT: gpio.OUT}
+
+        PULLUPS = {
+            PinPullup.OFF: gpio.PUD_OFF,
+            PinPullup.UP: gpio.PUD_UP,
+            PinPullup.DOWN: gpio.PUD_DOWN,
+        }
+
+        board = config["board"].upper()
+        if not hasattr(gpio, board):
+            raise AssertionError("%s board not found" % board)
+        gpio.setboard(getattr(gpio, board))
+        gpio.setmode(gpio.BCM)
+
+    def setup_pin(self, pin, direction, pullup, pin_config):
+        direction = DIRECTIONS[direction]
+
+        if pullup is None:
+            pullup = PULLUPS[PinPullup.OFF]
+        else:
+            pullup = PULLUPS[pullup]
+
+        initial = {None: -1, "low": 0, "high": 1}[pin_config.get("initial")]
+        self.io.setup(pin, direction, pull_up_down=pullup, initial=initial)
+
+    def set_pin(self, pin, value):
+        self.io.output(pin, value)
+
+    def get_pin(self, pin):
+        return self.io.input(pin)
+
+    def cleanup(self):
+        self.io.cleanup()


### PR DESCRIPTION
Working and tested Orange Pi support.
Pretty much it is the same as #30 pull request, but finalised.

It is recommended to use `mode`:`board`. It is complicated to find a pinout with `BCM` numbers.