### PR TITLE
Feature/module gpiod

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ GPIO Modules
 - PCF8575 IO chip (`pcf8575`)
 - PiFaceDigital 2 IO board (`piface2`)
 - Beaglebone GPIO (`beaglebone`)
+- Linux Kernel 4.8+ GPIOd (`gpiod`)
 
 Sensors
 -------

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ GPIO Modules
 - PCF8575 IO chip (`pcf8575`)
 - PiFaceDigital 2 IO board (`piface2`)
 - Beaglebone GPIO (`beaglebone`)
-- Linux Kernel 4.8+ GPIOd (`gpiod`)
+- Linux Kernel 4.8+ libgpiod (`gpiod`)
 
 Sensors
 -------

--- a/config.example.yml
+++ b/config.example.yml
@@ -23,6 +23,10 @@ gpio_modules:
     board: zero
     mode: board
 
+  - name: gpiochip0
+    module: gpiod
+    chip: /dev/gpiochip0
+
 sensor_modules:
   - name: lm75
     module: lm75

--- a/pi_mqtt_gpio/__init__.py
+++ b/pi_mqtt_gpio/__init__.py
@@ -148,6 +148,11 @@ sensor_modules:
         type: boolean
         required: no
         default: yes
+      chip:
+        type: string
+        required: no
+        default: "/dev/gpiochip0"
+        empty: no
 
 stream_modules:
   type: list

--- a/pi_mqtt_gpio/__init__.py
+++ b/pi_mqtt_gpio/__init__.py
@@ -127,6 +127,10 @@ gpio_modules:
         type: boolean
         required: no
         default: yes
+      chip:
+        type: string
+        required: no
+        default: "/dev/gpiochip0"
 
 sensor_modules:
   type: list

--- a/pi_mqtt_gpio/__init__.py
+++ b/pi_mqtt_gpio/__init__.py
@@ -152,11 +152,6 @@ sensor_modules:
         type: boolean
         required: no
         default: yes
-      chip:
-        type: string
-        required: no
-        default: "/dev/gpiochip0"
-        empty: no
 
 stream_modules:
   type: list

--- a/pi_mqtt_gpio/__init__.py
+++ b/pi_mqtt_gpio/__init__.py
@@ -127,10 +127,6 @@ gpio_modules:
         type: boolean
         required: no
         default: yes
-      chip:
-        type: string
-        required: no
-        default: "/dev/gpiochip0"
 
 sensor_modules:
   type: list

--- a/pi_mqtt_gpio/modules/__init__.py
+++ b/pi_mqtt_gpio/modules/__init__.py
@@ -8,6 +8,7 @@ BASE_SCHEMA = {
     "name": {"required": True, "empty": False},
     "module": {"required": True, "empty": False},
     "cleanup": {"required": False, "type": "boolean", "default": True},
+    "chip": {"required": False, "type": "string", "default": "/dev/gpiochip0"},
 }
 
 

--- a/pi_mqtt_gpio/modules/__init__.py
+++ b/pi_mqtt_gpio/modules/__init__.py
@@ -7,8 +7,7 @@ from time import sleep
 BASE_SCHEMA = {
     "name": {"required": True, "empty": False},
     "module": {"required": True, "empty": False},
-    "cleanup": {"required": False, "type": "boolean", "default": True},
-    "chip": {"required": False, "type": "string", "default": "/dev/gpiochip0"},
+    "cleanup": {"required": False, "type": "boolean", "default": True}
 }
 
 

--- a/pi_mqtt_gpio/modules/gpiod.py
+++ b/pi_mqtt_gpio/modules/gpiod.py
@@ -22,7 +22,7 @@ class GPIO(GenericGPIO):
         import gpiod as gpio
 
         self.io = gpio
-        self.chip = config.chip
+        self.chip = gpio.chip(config["chip"])
         self.pins = {}
         self.watchers = {}
 

--- a/pi_mqtt_gpio/modules/gpiod.py
+++ b/pi_mqtt_gpio/modules/gpiod.py
@@ -28,12 +28,6 @@ class GPIO(GenericGPIO):
 
         DIRECTIONS = {PinDirection.INPUT: gpio.line_request.DIRECTION_INPUT, PinDirection.OUTPUT: gpio.line_request.DIRECTION_OUTPUT}
 
-        PULLUPS = {
-            PinPullup.OFF: gpio.line.BIAS_DISABLE,
-            PinPullup.UP: gpio.line.BIAS_PULL_UP,
-            PinPullup.DOWN: gpio.line.BIAS_PULL_DOWN,
-        }
-
         INTERRUPT = {
             InterruptEdge.RISING: gpio.line_request.EVENT_RISING_EDGE,
             InterruptEdge.FALLING: gpio.line_request.EVENT_FALLING_EDGE,
@@ -55,7 +49,6 @@ class GPIO(GenericGPIO):
         # yet part of python3-gpiod.
 
         pin = self.chip.get_line(offset)
-        pin.bias = pullup
 
         config = self.io.line_request()
         config.consumer = 'pi-mqtt-gpio'

--- a/pi_mqtt_gpio/modules/gpiod.py
+++ b/pi_mqtt_gpio/modules/gpiod.py
@@ -52,8 +52,7 @@ class GPIO(GenericGPIO):
         pin.bias = pullup
 
         config = self.io.line_request()
-        config.consumer = 'pin' + offset
-        config.request_type = direction
+        config.consumer = 'pi-mqtt-gpio'
 
         pin.request(config)
         self.pins[offset] = pin
@@ -73,7 +72,7 @@ class GPIO(GenericGPIO):
         pin = self.chip.get_line(offset)
 
         config = self.io.line_request()
-        config.consumer = 'pin' + offset
+        config.consumer = 'pi-mqtt-gpio'
         config.request_type = edge
 
         self.loop.create_task(self._add_event_detect(pin, self.interrupt_callback))

--- a/pi_mqtt_gpio/modules/gpiod.py
+++ b/pi_mqtt_gpio/modules/gpiod.py
@@ -49,21 +49,18 @@ class GPIO(GenericGPIO):
         direction:  input or output
         pullup:     pullup settings are not supported
         """
-        line_direction = DIRECTIONS[direction]
-        offset = pin
-
         # Pullup settings are called bias in libgpiod and are only
         # available since Linux Kernel 5.5. They are as of now not 
         # yet part of python3-gpiod.
 
-        pin = self.chip.get_line(offset)
+        line = self.chip.get_line(pin)
 
         config = self.io.line_request()
         config.consumer = 'pi-mqtt-gpio'
-        config.request_type = line_direction
+        config.request_type = DIRECTIONS[direction]
 
-        pin.request(config)
-        self.pins[offset] = pin
+        line.request(config)
+        self.pins[pin] = line
 
     def setup_interrupt(self, handle, pin, edge, callback, bouncetime=100):
         """

--- a/pi_mqtt_gpio/modules/gpiod.py
+++ b/pi_mqtt_gpio/modules/gpiod.py
@@ -66,6 +66,28 @@ class GPIO(GenericGPIO):
         pin.request(config)
         self.pins[offset] = pin
 
+    def setup_interrupt(self, handle, pin, edge, callback, bouncetime=100):
+        """
+        install interrupt callback function
+        handle:     is returned in the callback function as identification
+        pin:        gpio to watch for interrupts
+        edge:       triggering edge: RISING, FALLING or BOTH
+        callback:   the callback function to be called, when interrupt occurs
+        bouncetime: minimum time between two interrupts
+        """
+
+        config = self.io.line_request()
+        config.consumer = 'pi-mqtt-gpio'
+        config.request_type = INTERRUPT[edge]
+        
+        t = GpioThread(chip=self.chip, offset=pin, config=config, 
+                callback=callback, bouncetime=bouncetime)
+        t.start()
+
+        self.watchers[offset] = t
+        self.GPIO_INTERRUPT_CALLBACK_LOOKUP[offset] = {"handle": t.handle,
+                                                    "callback": callback}
+
     def set_pin(self, pin, value):
         offset = pin
         self.pins[offset].set_value(value)
@@ -76,3 +98,38 @@ class GPIO(GenericGPIO):
 
     def cleanup(self):
         pass
+
+class GpioThread(threading.Thread):
+    def __init__(self, chip, offset, config, callback, bouncetime):
+        super().__init__()
+        self.daemon = True
+        self._queue = queue.Queue()
+
+        self.pin = chip.get_line(offset)
+        self.pin.request(config)
+        self.callback = callback
+        self.bouncetime = timedelta(microseconds=bouncetime)
+
+    def run(self):
+        previous_event_time = datetime.now()
+        while True:
+            if self.pin.event_wait():
+                event = self.pin.event_read()
+                if event.timestamp - previous_event_time > self.bouncetime:
+                    previous_event_time = event.timestamp
+
+                    ret = self.callback()
+                    self._queue.put(
+                        {
+                            "type": event.event_type,
+                            "time": event.timestamp,
+                            "result": ret,
+                        }
+                    )
+
+    @property
+    def handle(self):
+        if self._queue.empty():
+            return None
+
+        return self._queue.get()

--- a/pi_mqtt_gpio/modules/gpiod.py
+++ b/pi_mqtt_gpio/modules/gpiod.py
@@ -40,7 +40,7 @@ class GPIO(GenericGPIO):
         }
 
     def setup_pin(self, pin, direction, pullup, pin_config):
-        direction = DIRECTIONS[direction]
+        line_direction = DIRECTIONS[direction]
         offset = pin
 
         if pullup is None:
@@ -53,6 +53,7 @@ class GPIO(GenericGPIO):
 
         config = self.io.line_request()
         config.consumer = 'pi-mqtt-gpio'
+        config.request_type = line_direction
 
         pin.request(config)
         self.pins[offset] = pin

--- a/pi_mqtt_gpio/modules/gpiod.py
+++ b/pi_mqtt_gpio/modules/gpiod.py
@@ -3,6 +3,7 @@ from pi_mqtt_gpio.modules import GenericGPIO, PinDirection, PinPullup, \
 
 from threading import Thread
 
+# Requires libgpiod-devel, libgpiod
 REQUIREMENTS = ("gpiod",)
 
 DIRECTIONS = None
@@ -13,7 +14,7 @@ GPIO_INTERRUPT_CALLBACK_LOOKUP = {}
 
 class GPIO(GenericGPIO):
     """
-    Implementation of GPIO class for Raspberry Pi native GPIO.
+    Implementation of GPIO class for libgpiod (linux kernel >= 4.8).
     """
 
     def __init__(self, config):
@@ -40,13 +41,18 @@ class GPIO(GenericGPIO):
         }
 
     def setup_pin(self, pin, direction, pullup, pin_config):
+        """
+        setup a pin as either input or output.
+        pin:        offset to use the gpio line
+        direction:  input or output
+        pullup:     pullup settings are not supported
+        """
         line_direction = DIRECTIONS[direction]
         offset = pin
 
-        if pullup is None:
-            pullup = PULLUPS[PinPullup.OFF]
-        else:
-            pullup = PULLUPS[pullup]
+        # Pullup settings are called bias in libgpiod and are only
+        # available since Linux Kernel 5.5. They are as of now not 
+        # yet part of python3-gpiod.
 
         pin = self.chip.get_line(offset)
         pin.bias = pullup

--- a/pi_mqtt_gpio/modules/gpiod.py
+++ b/pi_mqtt_gpio/modules/gpiod.py
@@ -88,8 +88,7 @@ class GPIO(GenericGPIO):
         return self.pins[offset].get_value()
 
     def cleanup(self):
-        self.loop.stop()
-        self.io.chip_deleter(self.chip)
+        pass
 
     async def _add_event_detect(self, pin, callback):
         while True:

--- a/pi_mqtt_gpio/modules/gpiod.py
+++ b/pi_mqtt_gpio/modules/gpiod.py
@@ -6,6 +6,14 @@ from threading import Thread
 # Requires libgpiod-devel, libgpiod
 REQUIREMENTS = ("gpiod",)
 
+CONFIG_SCHEMA = {
+    "chip": {
+        "type": "string",
+        "required": False,
+        "default": "/dev/gpiochip0"
+    }
+}
+
 DIRECTIONS = None
 PULLUPS = None
 INTERRUPT = None

--- a/pi_mqtt_gpio/modules/gpiod.py
+++ b/pi_mqtt_gpio/modules/gpiod.py
@@ -1,0 +1,98 @@
+from pi_mqtt_gpio.modules import GenericGPIO, PinDirection, PinPullup, \
+                                 InterruptEdge
+import asyncio
+
+REQUIREMENTS = ("gpiod",)
+
+DIRECTIONS = None
+PULLUPS = None
+INTERRUPT = None
+GPIO_INTERRUPT_CALLBACK_LOOKUP = {}
+
+
+class GPIO(GenericGPIO):
+    """
+    Implementation of GPIO class for Raspberry Pi native GPIO.
+    """
+
+    def __init__(self, config):
+        global DIRECTIONS, PULLUPS, INTERRUPT
+        import gpiod as gpio
+
+        self.io = gpio
+        self.chip = config.chip
+        self.pins = {}
+        self.loop = asyncio.get_event_loop()
+        self.loop.run_forever()
+
+        DIRECTIONS = {PinDirection.INPUT: gpio.line_request.DIRECTION_INPUT, PinDirection.OUTPUT: gpio.line_request.DIRECTION_OUTPUT}
+
+        PULLUPS = {
+            PinPullup.OFF: gpio.line.BIAS_DISABLE,
+            PinPullup.UP: gpio.line.BIAS_PULL_UP,
+            PinPullup.DOWN: gpio.line.BIAS_PULL_DOWN,
+        }
+
+        INTERRUPT = {
+            InterruptEdge.RISING: gpio.line_request.EVENT_RISING_EDGE,
+            InterruptEdge.FALLING: gpio.line_request.EVENT_FALLING_EDGE,
+            InterruptEdge.BOTH: gpio.line_request.EVENT_BOTH_EDGES
+        }
+
+    def setup_pin(self, pin, direction, pullup, pin_config):
+        direction = DIRECTIONS[direction]
+        offset = pin
+
+        if pullup is None:
+            pullup = PULLUPS[PinPullup.OFF]
+        else:
+            pullup = PULLUPS[pullup]
+
+        pin = self.chip.get_line(offset)
+        pin.bias = pullup
+
+        config = self.io.line_request()
+        config.consumer = 'pin' + offset
+        config.request_type = direction
+
+        pin.request(config)
+        self.pins[offset] = pin
+
+    def setup_interrupt(self, handle, pin, edge, callback, bouncetime=100):
+        """
+        install interrupt callback function
+        handle:     is returned in the callback function as identification
+        pin:        gpio to watch for interrupts
+        edge:       triggering edge: RISING, FALLING or BOTH
+        callback:   the callback function to be called, when interrupt occurs
+        bouncetime: minimum time between two interrupts
+        """
+        edge = INTERRUPT[edge]
+        offset = pin
+
+        pin = self.chip.get_line(offset)
+
+        config = self.io.line_request()
+        config.consumer = 'pin' + offset
+        config.request_type = edge
+
+        self.loop.create_task(self._add_event_detect(pin, self.interrupt_callback))
+        self.GPIO_INTERRUPT_CALLBACK_LOOKUP[offset] = {"handle": handle,
+                                                    "callback": callback}
+
+    def set_pin(self, pin, value):
+        offset = pin
+        self.pins[offset].set_value(value)
+
+    def get_pin(self, pin):
+        offset = pin
+        return self.pins[offset].get_value()
+
+    def cleanup(self):
+        self.loop.stop()
+        self.io.chip_deleter(self.chip)
+
+    async def _add_event_detect(self, pin, callback):
+        while True:
+            if pin.event_wait():
+                callback()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ paho-mqtt
 PyYAML>=5.3.1
 enum34
 cerberus
-gpiod

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ paho-mqtt
 PyYAML>=5.3.1
 enum34
 cerberus
-
+gpiod


### PR DESCRIPTION
This PR adds the gpiod (General Purpose Input Output Device) module (through libgpiod[1] and python3-libgpiod[2]) introduced with linux kernel 4.8.

The module uses the `/dev/gpiochipN` chardev to access the GPIOs of a system.

This module uses threading to add support for callback-style interrupts, which are not yet upstream.

Bias (Pullup) settings are introduced in kernel 5.5+ but are not yet part of the python3-libgpiod module. This renders it inferior to the sysfs based modules as of now.

Distributions like Fedora IoT ship without the deprecated sysfs interface `/sys/class/gpio...` and instead use the new kernel driver libgpiod.

The code was tested in it's current state with LEDs and Buttons on a Raspberry Pi 3 B+ with Fedora IoT 31.

Dependencies
---

The module requires libgpiod and libgpiod-devel (development files) on the host system.

It relies on python3-libgpiod.

References
---

[1] <https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git>
[2] <https://pypi.org/project/gpiod/>
[3] <https://www.beyondlogic.org/an-introduction-to-chardev-gpio-and-libgpiod-on-the-raspberry-pi/>