### PR TITLE
Add PCF8575 Module Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ GPIO Modules
 - Raspberry Pi GPIO (`raspberrypi`)
 - Orange Pi GPIO (`orangepi`)
 - PCF8574 IO chip (`pcf8574`)
+- PCF8575 IO chip (`pcf8575`)
 - PiFaceDigital 2 IO board (`piface2`)
 - Beaglebone GPIO (`beaglebone`)
 

--- a/pi_mqtt_gpio/modules/pcf8575.py
+++ b/pi_mqtt_gpio/modules/pcf8575.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import
+
+from pi_mqtt_gpio.modules import GenericGPIO, PinDirection, PinPullup
+
+
+REQUIREMENTS = ("pcf8575",)
+CONFIG_SCHEMA = {
+    "i2c_bus_num": {"type": "integer", "required": True, "empty": False},
+    "chip_addr": {"type": "integer", "required": True, "empty": False},
+}
+
+PULLUPS = None
+
+
+class GPIO(GenericGPIO):
+    """
+    Implementation of GPIO class for the pcf8575 IO expander chip.
+    """
+
+    def __init__(self, config):
+        global PULLUPS
+        PULLUPS = {PinPullup.UP: True, PinPullup.DOWN: False}
+        from pcf8575 import pcf8575
+
+        self.io = pcf8575(config["i2c_bus_num"], config["chip_addr"])
+
+    def setup_pin(self, pin, direction, pullup, pin_config):
+        if direction == PinDirection.INPUT and pullup is not None:
+            self.io.port[pin] = PULLUPS[pullup]
+        initial = pin_config.get("initial")
+        if initial is not None:
+            if initial == "high":
+                self.set_pin(pin, True)
+            elif initial == "low":
+                self.set_pin(pin, False)
+
+    def set_pin(self, pin, value):
+        self.io.port[pin] = value
+
+    def get_pin(self, pin):
+        return self.io.port[pin]


### PR DESCRIPTION
PCF8575 from PCF8574 differs only on I/O count:
- PCF8574 - 8 pins
- PCF8575 - 16 pins

[PCF8575 library](https://pypi.org/project/pcf8575/) is a modified version of the [PCF8574 library](https://github.com/flyte/pcf8574) to support the extra 8 ports.