### PR TITLE
Add optional display name for HomeAssistant discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,17 @@ mqtt:
   discovery_name: "device1" # optional
 ```
 
+The optional value `display_name` can be used to set an human readable name that will be displayed instead of the technical name `name`:
+
+```yaml
+sensor_inputs:
+  - name: lm75_temperature
+    display_name: LM75 Temperature # optional
+    module: lm75_sensor
+    interval: 15
+    digits: 4
+```
+
 ### Logging
 
 Logging may be configured by including a `logging` section in your `config.yml`. The standard Python logging system is used, so configuration questions should be answered by looking at [the Python logging howto](https://docs.python.org/3/howto/logging.html).

--- a/README.md
+++ b/README.md
@@ -392,6 +392,17 @@ mqtt:
   topic_prefix: home/office
 ```
 
+#### HomeAssistant discovery
+
+Metadata of all `sensor_inputs`, `digital_inputs` and `digital_outputs` can be published via HomeAssistant config messages to be discovered by a HomeAssistant instance that is listening on the same MQTT broker:
+
+```yaml
+mqtt:
+  discovery: yes
+  discovery_prefix: "homeassistant" # optional
+  discovery_name: "device1" # optional
+```
+
 ### Logging
 
 Logging may be configured by including a `logging` section in your `config.yml`. The standard Python logging system is used, so configuration questions should be answered by looking at [the Python logging howto](https://docs.python.org/3/howto/logging.html).

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -177,6 +177,10 @@ digital_inputs:
         type: string
         required: yes
         empty: no
+      display_name:
+        type: string
+        required: no
+        empty: no
       module:
         type: string
         required: yes
@@ -240,6 +244,10 @@ digital_outputs:
       name:
         type: string
         required: yes
+      display_name:
+        type: string
+        required: no
+        empty: no
       module:
         type: string
         required: yes
@@ -291,6 +299,10 @@ sensor_inputs:
       name:
         type: string
         required: yes
+        empty: no
+      display_name:
+        type: string
+        required: no
         empty: no
       module:
         type: string

--- a/pi_mqtt_gpio/__init__.py
+++ b/pi_mqtt_gpio/__init__.py
@@ -181,6 +181,10 @@ digital_inputs:
         type: string
         required: yes
         empty: no
+      display_name:
+        type: string
+        required: no
+        empty: no
       module:
         type: string
         required: yes
@@ -244,6 +248,10 @@ digital_outputs:
       name:
         type: string
         required: yes
+      display_name:
+        type: string
+        required: no
+        empty: no
       module:
         type: string
         required: yes
@@ -295,6 +303,10 @@ sensor_inputs:
       name:
         type: string
         required: yes
+        empty: no
+      display_name:
+        type: string
+        required: no
         empty: no
       module:
         type: string

--- a/pi_mqtt_gpio/server.py
+++ b/pi_mqtt_gpio/server.py
@@ -967,7 +967,7 @@ def hass_announce_digital_output(out_conf, topic_prefix, mqtt_config):
     )  # TODO: Unify with MQTT Client ID
     sensor_name = out_conf["name"]
     sensor_config = {
-        "name": sensor_name,
+        "name": out_conf.get("display_name", None) or sensor_name,
         "unique_id": "%s_%s_output_%s" % (device_id, out_conf["module"], sensor_name),
         "state_topic": "%s/%s/%s" % (topic_prefix, OUTPUT_TOPIC, out_conf["name"]),
         "command_topic": "%s/%s/%s/%s"
@@ -1005,7 +1005,7 @@ def hass_announce_sensor_input(in_conf, topic_prefix, mqtt_config):
     )  # TODO: Unify with MQTT Client ID
     sensor_name = in_conf["name"]
     sensor_config = {
-        "name": sensor_name,
+        "name": out_conf.get("display_name", None) or sensor_name,
         "unique_id": "%s_%s_output_%s" % (device_id, in_conf["module"], sensor_name),
         "state_topic": "%s/%s/%s" % (topic_prefix, SENSOR_TOPIC, in_conf["name"]),
         "availability_topic": "%s/%s" % (topic_prefix, mqtt_config["status_topic"]),


### PR DESCRIPTION
1. Documents activation of HomeAssistant MQTT discovery
2. Adds the option to set a human readable name  per input/output pin, or sensor. This allows for example to use spaces and german umlauts.