### PR TITLE
re-define component config option

### DIFF
--- a/config.schema.yml
+++ b/config.schema.yml
@@ -236,6 +236,10 @@ digital_inputs:
         type: boolean
         required: no
         default: no
+      component:
+        type: string
+        required: no
+        default: binary_sensor
 
 digital_outputs:
   type: list
@@ -288,6 +292,10 @@ digital_outputs:
         type: boolean
         required: no
         default: no
+      component:
+        type: string
+        required: no
+        default: switch
 
 sensor_inputs:
   type: list
@@ -322,6 +330,10 @@ sensor_inputs:
       unit_of_measurement:
         type: string
         required: no
+      component:
+        type: string
+        required: no
+        default: sensor
 
 stream_reads:
   type: list

--- a/pi_mqtt_gpio/server.py
+++ b/pi_mqtt_gpio/server.py
@@ -950,7 +950,7 @@ def hass_announce_digital_input(in_conf, topic_prefix, mqtt_config):
 
     client.publish(
         "%s/%s/%s/%s/config"
-        % (mqtt_config["discovery_prefix"], "binary_sensor", device_id, sensor_name),
+        % (mqtt_config["discovery_prefix"], in_conf. get("component", "binary_sensor"), device_id, sensor_name),
         payload=json.dumps(sensor_config),
         retain=True,
     )
@@ -988,7 +988,7 @@ def hass_announce_digital_output(out_conf, topic_prefix, mqtt_config):
 
     client.publish(
         "%s/%s/%s/%s/config"
-        % (mqtt_config["discovery_prefix"], "switch", device_id, sensor_name),
+        % (mqtt_config["discovery_prefix"], out_conf. get("component", "switch"), device_id, sensor_name),
         payload=json.dumps(sensor_config),
         retain=True,
     )
@@ -1025,7 +1025,7 @@ def hass_announce_sensor_input(in_conf, topic_prefix, mqtt_config):
 
     client.publish(
         "%s/%s/%s/%s/config"
-        % (mqtt_config["discovery_prefix"], "sensor", device_id, sensor_name),
+        % (mqtt_config["discovery_prefix"], in_conf.get("component", "sensor"), device_id, sensor_name),
         payload=json.dumps(sensor_config),
         retain=True,
     )


### PR DESCRIPTION
"component" defaults: "sensor" for sensor, “binary_sensor” for input, “switch” for output