### PR TITLE
fix inverted for digital inputs. Further fix retain for digital inputs, sensors and streams

### DIFF
--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -337,7 +337,8 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
         # Needs to be a function, not a method, hence the closure function.
         async def publish_callback(event: DigitalInputChangedEvent) -> None:
             in_conf = self.digital_input_configs[event.input_name]
-            val = in_conf["on_payload"] if event.to_value else in_conf["off_payload"]
+            value = event.to_value != in_conf["inverted"]
+            val = in_conf["on_payload"] if value else in_conf["off_payload"]
             self.mqtt_task_queue.put_nowait(
                 PriorityCoro(
                     self._mqtt_publish(

--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -262,6 +262,7 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
                                 )
                             ),
                             event.data,
+                            retain=stream_conf["retain"],
                         )
                     ),
                     MQTT_PUB_PRIORITY,
@@ -485,6 +486,7 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
 
     def _init_sensor_inputs(self) -> None:
         async def publish_sensor_callback(event: SensorReadEvent) -> None:
+            sensor_conf = self.sensor_configs[event.sensor_name]
             self.mqtt_task_queue.put_nowait(
                 PriorityCoro(
                     self._mqtt_publish(
@@ -497,6 +499,7 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
                                 )
                             ),
                             str(event.value).encode("utf8"),
+                            retain=sensor_conf["retain"],
                         )
                     ),
                     MQTT_PUB_PRIORITY,

--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -351,6 +351,7 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
                                 )
                             ),
                             val.encode("utf8"),
+                            retain=in_conf["retain"],
                         )
                     ),
                     MQTT_PUB_PRIORITY,


### PR DESCRIPTION
I tried to use inverted with digital inputs and detected that it did not have any kind of effect. Looking deeper I realized that it is already part of the scheme but only used for digital outputs. Thus I consider that it got broken at some point in the past