### PR TITLE
Add install_requirements flag to all modules

### DIFF
--- a/mqtt_io/config/config.schema.yml
+++ b/mqtt_io/config/config.schema.yml
@@ -299,6 +299,12 @@ gpio_modules:
         type: boolean
         required: no
         default: yes
+      install_requirements:
+        meta:
+          description: Whether to run `pip install` for all the requirements in the module.
+        type: boolean
+        required: no
+        default: yes
 
 sensor_modules:
   meta:
@@ -346,6 +352,12 @@ sensor_modules:
       cleanup:
         meta:
           description: Whether to run the module's `cleanup()` method on exit.
+        type: boolean
+        required: no
+        default: yes
+      install_requirements:
+        meta:
+          description: Whether to run `pip install` for all the requirements in the module.
         type: boolean
         required: no
         default: yes
@@ -433,6 +445,12 @@ stream_modules:
         type: boolean
         required: no
         default: yes
+      install_requirements:
+        meta:
+          description: Whether to run `pip install` for all the requirements in the module.
+        type: boolean
+        required: no
+        default: yes
 
 digital_inputs:
   meta:
@@ -447,7 +465,7 @@ digital_inputs:
       gpio_modules:
         - name: rpi
           module: raspberrypi
-      
+
       digital_inputs:
         - name: gpio0
           module: rpi
@@ -537,8 +555,7 @@ digital_inputs:
           description: |
             Enable the pull-up resistor for this input so that the logic level is pulled
             "high" by default.
-          extra_info:
-            Not all GPIO modules support pull-up resistors.
+          extra_info: Not all GPIO modules support pull-up resistors.
         type: boolean
         required: no
         default: no
@@ -547,8 +564,7 @@ digital_inputs:
           description: |
             Enable the pull-down resistor for this input so that the logic level is pulled
             "low" by default.
-          extra_info:
-            Not all GPIO modules support pull-down resistors.
+          extra_info: Not all GPIO modules support pull-down resistors.
         type: boolean
         required: no
         default: no
@@ -666,7 +682,7 @@ digital_outputs:
       gpio_modules:
         - name: rpi
           module: raspberrypi
-      
+
       digital_outputs:
         - name: gpio0
           module: rpi
@@ -836,7 +852,7 @@ sensor_inputs:
           module: dht22
           type: AM2302
           pin: 4
-      
+
       sensor_inputs:
         - name: workshop_temp
           module: dht
@@ -996,4 +1012,3 @@ reporting:
           want to provide additional context to help the developers diagnose the issue.
       type: integer
       required: no
-

--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -112,7 +112,8 @@ def _init_module(
     # Add the module's config schema to the base schema
     module_schema.update(getattr(module, "CONFIG_SCHEMA", {}))
     module_config = validate_and_normalise_config(module_config, module_schema)
-    install_missing_module_requirements(module)
+    if module_config.get('install_requirements', True):
+        install_missing_module_requirements(module)
     module_class: Type[Union[GenericGPIO, GenericSensor, GenericStream]] = getattr(
         module, MODULE_CLASS_NAMES[module_type]
     )


### PR DESCRIPTION
I'm running mqtt-io on a raspberry pi zero w and it takes about 3 minutes to start. 2 and a half are the requirements check, because pip is really slow on this hardware. I'd like to skip the `pip install` step on startup, because I've already checked the requirements and they are fine. So on future starts this should not be checked any more. 

This PR adds a new flag to the modules section in the config to skip `pip install`