### PR TITLE
Fix initial state publish

### DIFF
--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -497,7 +497,8 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
             if out_conf["publish_initial"]:
                 self.event_bus.fire(
                     DigitalOutputChangedEvent(
-                        out_conf["name"], out_conf["initial"] == "high"
+                        out_conf["name"], out_conf["initial"] == (
+                            "low" if out_conf["inverted"] else "high")
                     )
                 )
 


### PR DESCRIPTION
I've run into a problem with my relais I use with `digital_outputs`. The relais needs inverted outputs so `ON` = `low` and `OFF` = `high`. I've used the `inverted` setting and can control the relais fine via MQTT. If I enable the `publish_initial` the initial message is always `ON` as the `initial_state` is `high` (to not activate the relais). 

The [initial publish](https://github.com/flyte/mqtt-io/blob/develop/mqtt_io/server.py#L500) event does not respect the inverted config. 

Here's my example config:

```yaml
mqtt:
  host: '1.2.3.4'
  topic_prefix: mypi
  user: 'mypi'
  password: 'password'
  ha_discovery:
    enabled: true

options:
  install_requirements: no

gpio_modules:
  - name: rpi
    module: raspberrypi

digital_outputs:
  - name: rainpi_1
    module: rpi
    pin: 5
    inverted: true
    initial: high
    publish_initial: true
    ha_discovery:
      name: 'Raspberry Pi Relais 1'
```

With this fix the inverted flag will be checked