### PR TITLE
Log uncaught exceptions to configured logging handlers

### DIFF
--- a/mqtt_io/__main__.py
+++ b/mqtt_io/__main__.py
@@ -16,6 +16,8 @@ from .exceptions import ConfigValidationFailed
 from .modules import install_missing_requirements
 from .server import MqttIo
 
+_LOG = logging.getLogger('mqtt_io.__main__')
+
 
 def hashed(value: Any) -> str:
     """
@@ -75,9 +77,12 @@ def main() -> None:
         sentry_sdk.set_context("config", redact_config(config))
         if issue_id is not None:
             sentry_sdk.set_tag("issue_id", issue_id)
-
-    mqtt_gpio = MqttIo(config)
-    mqtt_gpio.run()
+    try:
+        mqtt_gpio = MqttIo(config)
+        mqtt_gpio.run()
+    except BaseException:
+        _LOG.exception('MqttIo crashed!')
+        raise
 
 
 if __name__ == "__main__":

--- a/mqtt_io/__main__.py
+++ b/mqtt_io/__main__.py
@@ -80,7 +80,7 @@ def main() -> None:
     try:
         mqtt_gpio = MqttIo(config)
         mqtt_gpio.run()
-    except BaseException:
+    except Exception:
         _LOG.exception('MqttIo crashed!')
         raise
 

--- a/mqtt_io/modules/sensor/mcp3008.py
+++ b/mqtt_io/modules/sensor/mcp3008.py
@@ -17,7 +17,7 @@ CONFIG_SCHEMA = {
     "chip_addr": dict(type="integer", required=False, empty=False, default=0),
 }
 
-_LOG = logging.getLogger("mqtt_gpio")
+_LOG = logging.getLogger(__name__)
 
 
 class Sensor(GenericSensor):


### PR DESCRIPTION
Fixes #202 

This PR logs exceptions of MqttIo.run() in main to the configured loggers.

I also fixed that the logger of mcp3008.py was named 'mqtt_gpio'