### PR TITLE
Auto-Reconnect on failure

### DIFF
--- a/mqtt_io/config/config.schema.yml
+++ b/mqtt_io/config/config.schema.yml
@@ -250,7 +250,24 @@ mqtt:
           type: boolean
           required: no
           default: false
-
+    reconnect-delay:
+      meta:
+        description: |
+          Time in seconds to wait between reconnect attempts.
+      type: integer
+      required: no
+      default: 2
+      min: 1
+    reconnect-count:
+      meta:
+        description: |
+          Max number of retries of connections before giving up (and exiting).
+          -1 means infinite reconnects.
+          The counter is reset if a connection was established successfully.
+      type: integer
+      required: no
+      default: 0
+      min: -1
 gpio_modules:
   meta:
     description: |

--- a/mqtt_io/config/config.schema.yml
+++ b/mqtt_io/config/config.schema.yml
@@ -250,7 +250,7 @@ mqtt:
           type: boolean
           required: no
           default: false
-    reconnect-delay:
+    reconnect_delay:
       meta:
         description: |
           Time in seconds to wait between reconnect attempts.
@@ -258,7 +258,7 @@ mqtt:
       required: no
       default: 2
       min: 1
-    reconnect-count:
+    reconnect_count:
       meta:
         description: |
           Max number of retries of connections before giving up (and exiting).

--- a/mqtt_io/config/config.schema.yml
+++ b/mqtt_io/config/config.schema.yml
@@ -262,11 +262,11 @@ mqtt:
       meta:
         description: |
           Max number of retries of connections before giving up (and exiting).
-          -1 means infinite reconnects.
+          -1 (the default) means infinite reconnects.
           The counter is reset if a connection was established successfully.
       type: integer
       required: no
-      default: 0
+      default: -1
       min: -1
 gpio_modules:
   meta:

--- a/mqtt_io/mqtt/__init__.py
+++ b/mqtt_io/mqtt/__init__.py
@@ -162,3 +162,7 @@ class AbstractMQTTClient(abc.ABC):
         client: Type[AbstractMQTTClient]
         client = client_module.MQTTClient  # type: ignore[attr-defined]
         return client
+
+
+class MQTTException(Exception):
+    pass

--- a/mqtt_io/mqtt/__init__.py
+++ b/mqtt_io/mqtt/__init__.py
@@ -165,4 +165,6 @@ class AbstractMQTTClient(abc.ABC):
 
 
 class MQTTException(Exception):
-    pass
+    """
+    An Exception which should be raised on errors in implementations of AbstractMQTTClient
+    """

--- a/mqtt_io/mqtt/asyncio_mqtt.py
+++ b/mqtt_io/mqtt/asyncio_mqtt.py
@@ -8,7 +8,7 @@ from asyncio.queues import QueueFull
 from functools import wraps
 from typing import Any, List, Optional, Tuple, TypeVar, Callable, cast
 
-from asyncio_mqtt.client import Client, Will  # type: ignore
+from asyncio_mqtt.client import Client, Will, MqttError  # type: ignore
 from paho.mqtt import client as paho  # type: ignore
 
 from . import (
@@ -29,7 +29,7 @@ def _map_exception(func: Func) -> Func:
     async def inner(*args: Any, **kwargs: Any) -> Any:
         try:
             await func(*args, **kwargs)
-        except Exception as exc:
+        except MqttError as exc:
             raise MQTTException from exc
 
     return cast(Func, inner)

--- a/mqtt_io/mqtt/asyncio_mqtt.py
+++ b/mqtt_io/mqtt/asyncio_mqtt.py
@@ -27,8 +27,8 @@ def _map_exception(func):
     async def inner(*args, **kwargs):
         try:
             await func(*args, **kwargs)
-        except Exception as e:
-            raise MQTTException from e
+        except Exception as exc:
+            raise MQTTException from exc
 
     return inner
 

--- a/mqtt_io/mqtt/asyncio_mqtt.py
+++ b/mqtt_io/mqtt/asyncio_mqtt.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from asyncio.queues import QueueFull
 from functools import wraps
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, TypeVar, Callable, cast
 
 from asyncio_mqtt.client import Client, Will  # type: ignore
 from paho.mqtt import client as paho  # type: ignore
@@ -21,16 +21,18 @@ from . import (
 
 _LOG = logging.getLogger(__name__)
 
+Func = TypeVar('Func', bound=Callable[..., Any])
 
-def _map_exception(func):
+
+def _map_exception(func: Func) -> Func:
     @wraps(func)
-    async def inner(*args, **kwargs):
+    async def inner(*args: Any, **kwargs: Any) -> Any:
         try:
             await func(*args, **kwargs)
         except Exception as exc:
             raise MQTTException from exc
 
-    return inner
+    return cast(Func, inner)
 
 
 class MQTTClient(AbstractMQTTClient):

--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -1184,6 +1184,8 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
             finally:
                 self.running.clear()
                 self.mqtt_connected.clear()
+                if self.critical_tasks:
+                    asyncio.gather(*self.critical_tasks, return_exceptions=True).cancel()
             if reconnect:
                 await asyncio.sleep(self.config['mqtt'].get('reconnect_delay'))
         await self.shutdown()

--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -19,7 +19,6 @@ from hashlib import sha1
 from importlib import import_module
 from typing import Any, Dict, List, Optional, Tuple, Type, Union, overload
 
-import asyncio_mqtt  # type: ignore
 import backoff  # type: ignore
 from typing_extensions import Literal
 
@@ -67,7 +66,7 @@ from .mqtt import (
     MQTTClientOptions,
     MQTTMessageSend,
     MQTTTLSOptions,
-    MQTTWill,
+    MQTTWill, MQTTException,
 )
 from .types import ConfigType, PinType, SensorValueType
 from .utils import PriorityCoro, create_unawaited_task_threadsafe
@@ -1175,7 +1174,7 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
                     _LOG.exception("Exception in critical task:")
             except asyncio.CancelledError:
                 break
-            except asyncio_mqtt.error.MqttError:
+            except MQTTException:
                 if counter > 0:
                     counter -= 1
                 _LOG.exception('Connection to MQTT-Broker failed')

--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -1175,11 +1175,11 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
             except asyncio.CancelledError:
                 break
             except MQTTException:
+                if counter == 0:
+                    break
                 if counter > 0:
                     counter -= 1
                 _LOG.exception('Connection to MQTT-Broker failed')
-                if counter == 0:
-                    break
                 await asyncio.sleep(self.config['mqtt'].get('reconnect_delay'))
             finally:
                 self.running.clear()

--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -1147,12 +1147,12 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
                 self.event_bus.fire(StreamDataSentEvent(stream_conf["name"], data))
 
     async def _main_loop(self) -> None:
-        counter = self.config['mqtt'].get('reconnect-count')
+        counter = self.config['mqtt'].get('reconnect_count')
         while True:
             try:
                 await self._connect_mqtt()
                 # Reset counter
-                counter = self.config['mqtt'].get('reconnect-count')
+                counter = self.config['mqtt'].get('reconnect_count')
                 self.critical_tasks = [
                     self.loop.create_task(coro)
                     for coro in (
@@ -1181,7 +1181,7 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
                 _LOG.exception('Connection to MQTT-Broker failed')
                 if counter == 0:
                     break
-                await asyncio.sleep(self.config['mqtt'].get('reconnect-delay'))
+                await asyncio.sleep(self.config['mqtt'].get('reconnect_delay'))
             finally:
                 self.running.clear()
         await self.shutdown()

--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -19,7 +19,7 @@ from hashlib import sha1
 from importlib import import_module
 from typing import Any, Dict, List, Optional, Tuple, Type, Union, overload
 
-import asyncio_mqtt
+import asyncio_mqtt  # type: ignore
 import backoff  # type: ignore
 from typing_extensions import Literal
 


### PR DESCRIPTION
Fixes #187 

This PR adds two new configuration-options:
reconnect-delay: `Time in seconds to wait between reconnect attempts.`

reconnect-count: 
`Max number of retries of connections before giving up (and exiting).
-1 means infinite reconnects.
The counter is reset if a connection was established successfully.
`