### PR TITLE
render config with confp

### DIFF
--- a/mqtt_io/__main__.py
+++ b/mqtt_io/__main__.py
@@ -8,10 +8,14 @@ from copy import deepcopy
 from hashlib import sha256
 from typing import Any, Optional
 
+import yaml
+
+from confp import render
+
 from mqtt_io.types import ConfigType
 
 from . import VERSION
-from .config import load_main_config
+from .config import validate_and_normalise_main_config
 from .exceptions import ConfigValidationFailed
 from .modules import install_missing_requirements
 from .server import MqttIo
@@ -39,17 +43,32 @@ def redact_config(config: ConfigType) -> ConfigType:
     return ret
 
 
+def load_config(args):
+    with open(args.config, "r") as stream:
+        if args.render:
+            rendered = render(args.render, stream.read())
+            raw_config = yaml.safe_load(rendered)
+        else:
+            raw_config = yaml.safe_load(stream)
+    return raw_config
+
+
 def main() -> None:
     """
     Main entrypoint function.
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("config")
+    parser.add_argument("--render", help="""
+    A config file for confp for preprocessing the config file.
+    Doesn't need to contain a template section.
+    """)
     args = parser.parse_args()
 
     # Load, validate and normalise config, or quit.
     try:
-        config = load_main_config(args.config)
+        raw_config = load_config(args)
+        config = validate_and_normalise_main_config(raw_config)
     except ConfigValidationFailed as exc:
         print(str(exc), file=sys.stderr)
         sys.exit(1)

--- a/mqtt_io/__main__.py
+++ b/mqtt_io/__main__.py
@@ -44,6 +44,9 @@ def redact_config(config: ConfigType) -> ConfigType:
 
 
 def load_config(args):
+    """
+    Loads the config, and uses confp to render it if necessary.
+    """
     with open(args.config, "r") as stream:
         if args.render:
             rendered = render(args.render, stream.read())

--- a/mqtt_io/__main__.py
+++ b/mqtt_io/__main__.py
@@ -10,7 +10,7 @@ from typing import Any, Optional
 
 import yaml
 
-from confp import render
+from confp import render  # type: ignore
 
 from mqtt_io.types import ConfigType
 
@@ -43,13 +43,13 @@ def redact_config(config: ConfigType) -> ConfigType:
     return ret
 
 
-def load_config(args):
+def load_config(config: str, render_config: str) -> Any:
     """
     Loads the config, and uses confp to render it if necessary.
     """
-    with open(args.config, "r") as stream:
-        if args.render:
-            rendered = render(args.render, stream.read())
+    with open(config, "r") as stream:
+        if render_config:
+            rendered = render(render_config, stream.read())
             raw_config = yaml.safe_load(rendered)
         else:
             raw_config = yaml.safe_load(stream)
@@ -70,7 +70,7 @@ def main() -> None:
 
     # Load, validate and normalise config, or quit.
     try:
-        raw_config = load_config(args)
+        raw_config = load_config(args.config, args.render)
         config = validate_and_normalise_main_config(raw_config)
     except ConfigValidationFailed as exc:
         print(str(exc), file=sys.stderr)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ typing-extensions = "^3.7.4"
 dataclasses = { version = "^0.8", python = ">=3.6,<3.7" }
 asyncio-mqtt = "^0.8.1"
 backoff = "^1.10.0"
+confp = "^0.4.0"
 
 [tool.poetry.dev-dependencies]
 mock = { version = "^4.0.3", python = ">=3.6,<3.8" }


### PR DESCRIPTION
Fixes #209 

This PR adds the possibility to preprocess the config-file with confp by using a new (optional) command line argument
`--render` which should point to confp config file. The mqtt-io config file is used as template.

For that to work I made small changes to confp ( https://github.com/flyte/confp/pull/8 )

This PR is a draft, as confp must be added to the requirements, but I have to wait for a new release with the changes of https://github.com/flyte/confp/pull/8