### PR TITLE
Fix hcsr04 sensor

### DIFF
--- a/mqtt_io/modules/sensor/hcsr04.py
+++ b/mqtt_io/modules/sensor/hcsr04.py
@@ -6,7 +6,7 @@ import time
 from statistics import mean
 from typing import Any, Dict, List, Optional, cast
 
-from ...types import ConfigType, SensorValueType
+from ...types import CerberusSchemaType, ConfigType, SensorValueType
 from . import GenericSensor
 
 REQUIREMENTS = ("RPi.GPIO",)
@@ -22,7 +22,7 @@ REQUIREMENTS = ("RPi.GPIO",)
 # duration trigger pulse
 PULSE = 0.00001
 # sonic speed/2
-SPEED_2 = 17015
+SPEED_2 = 34300 / 2
 
 
 class HCSR04:
@@ -31,7 +31,8 @@ class HCSR04:
     attached to the Raspberry Pi's GPIO pins.
     """
 
-    def __init__(self, gpio: Any, name: str, pin_echo: int, pin_trigger: int, burst: int):
+    def __init__(self, gpio: Any, name: str, pin_echo: int, pin_trigger: int, burst: int,
+                 **kwargs: Any):
         self.gpio = gpio
         self.name = name
         self.pin_echo = pin_echo
@@ -58,9 +59,7 @@ class HCSR04:
                 delta = time.time() - self.start
                 self.distance = delta * SPEED_2
 
-        self.gpio.add_event_detect(
-            self.pin_echo, self.gpio.BOTH, callback=measure_callback
-        )
+        self.gpio.add_event_detect(self.pin_echo, self.gpio.BOTH, callback=measure_callback)
 
     def pulse(self) -> None:
         """
@@ -89,9 +88,7 @@ class HCSR04:
             measurements.append(cast(float, self.distance))
             time.sleep(0.05)
         if not measurements:
-            raise RuntimeError(
-                "Unable to measure range on HC-SR04 sensor '%s'" % self.name
-            )
+            raise RuntimeError("Unable to measure range on HC-SR04 sensor '%s'" % self.name)
         return mean(measurements)
 
 
@@ -100,10 +97,22 @@ class Sensor(GenericSensor):
     Implementation of the sensor using Raspberry Pi on-board GPIO.
     """
 
-    SENSOR_CONFIG = {
-        "pin_echo": {"type": "integer", "required": True, "empty": False},
-        "pin_trigger": {"type": "integer", "required": True, "empty": False},
-        "burst": {"type": "integer", "required": True, "empty": False},
+    SENSOR_SCHEMA: CerberusSchemaType = {
+        "pin_echo": {
+            "type": "integer",
+            "required": True,
+            "empty": False
+        },
+        "pin_trigger": {
+            "type": "integer",
+            "required": True,
+            "empty": False
+        },
+        "burst": {
+            "type": "integer",
+            "required": True,
+            "empty": False
+        },
     }
 
     def setup_module(self) -> None:
@@ -116,7 +125,7 @@ class Sensor(GenericSensor):
         self.sensors: Dict[str, HCSR04] = {}
 
     def setup_sensor(self, sens_conf: ConfigType) -> None:
-        sensor = HCSR04(**sens_conf)
+        sensor = HCSR04(gpio=self.gpio, **sens_conf)
         self.sensors[sensor.name] = sensor
 
     def get_value(self, sens_conf: ConfigType) -> SensorValueType:


### PR DESCRIPTION
Hi @flyte !

I tried to add a hcsr04 sensor to my mqtt-io instance, but I failed to configure it. The fields were not accepted in either the module or the sensor config. Once I fixed that, the constructor of the `HCSR04` class did not support the module argument, which has been passed from the Sensor config. Also the call of the constructor did not pass `gpio` to the instance.

This branch contains fixes for both issues and an adjustment of the [speed of sound at 20°C](https://en.wikipedia.org/wiki/Speed_of_sound). 

I've also thought about adding temperature as an argument, but this should be provided by some kind of sensor with an actual value and not from the config. Also the calculation can be easily reverted afterwards and adjusted to the current temperature. 