### PR TITLE
Add module gpiozero

### DIFF
--- a/mqtt_io/modules/gpio/gpiozero.py
+++ b/mqtt_io/modules/gpio/gpiozero.py
@@ -1,0 +1,96 @@
+"""
+GPIO Zero
+"""
+import logging
+from functools import partial
+from typing import Optional, Any, Callable, List, Dict, TYPE_CHECKING, cast
+
+from mqtt_io.modules.gpio import GenericGPIO, PinDirection, PinPUD, InterruptSupport, InterruptEdge
+from mqtt_io.types import PinType, ConfigType
+
+if TYPE_CHECKING:
+    # pylint: disable=import-error
+    import gpiozero  # type: ignore
+
+_LOG = logging.getLogger(__name__)
+REQUIREMENTS = ("gpiozero",)
+
+
+class GPIO(GenericGPIO):
+    """
+    Implementation of GPIO class for gpiozero
+    """
+    INTERRUPT_SUPPORT = InterruptSupport.SOFTWARE_CALLBACK
+    PIN_SCHEMA = {
+        "kwargs": {
+            "type": "dict", "required": False, "default": {},
+        }
+    }
+    INPUT_SCHEMA = {
+        "class": {"type": "string", "required": False, "default": "Button"}
+    }
+    OUTPUT_SCHEMA = {
+        "class": {"type": "string", "required": False, "default": "LED"}
+    }
+
+    def setup_module(self) -> None:
+        # pylint: disable=import-outside-toplevel,import-error
+        import gpiozero
+        self.io = gpiozero
+        self._pins: Dict[PinType, Any] = {}
+        self.pullup_map = {
+            PinPUD.OFF: None,
+            PinPUD.UP: True,
+            PinPUD.DOWN: False,
+        }
+
+    def setup_pin(
+            self,
+            pin: PinType,
+            direction: PinDirection,
+            pullup: PinPUD,
+            pin_config: ConfigType,
+            initial: Optional[str] = None
+    ) -> None:
+
+        if direction == PinDirection.OUTPUT:
+            pin_config.setdefault('initial_value', initial)
+            cls = getattr(self.io, pin_config.get('class', 'LED'))
+            self._pins[pin] = cls(pin, **pin_config.get('kwargs', {}))
+        elif direction == PinDirection.INPUT:
+            cls = getattr(self.io, pin_config.get('class', 'Button'))
+            pin_config.setdefault('pull_up', self.pullup_map[pullup])
+            pin_config.setdefault('active_state', True if pin_config['pull_up'] is None else None)
+            pin_config.setdefault('initial_value', initial)
+            self._pins[pin] = cls(pin, **pin_config.get('kwargs', {}))
+        else:
+            raise ValueError('Invalid PinDirection')
+
+    def set_pin(self, pin: PinType, value: bool) -> None:
+        if value:
+            self._pins[pin].on()
+        else:
+            self._pins[pin].off()
+
+    def get_pin(self, pin: PinType) -> bool:
+        return cast(bool, self._pins[pin].is_active)
+
+    def setup_interrupt_callback(
+            self,
+            pin: PinType,
+            edge: InterruptEdge,
+            in_conf: ConfigType,
+            callback: Callable[[List[Any], Dict[Any, Any]], None],
+    ) -> None:
+        _LOG.debug(
+            "Added interrupt to gpiozero Pi pin '%s' with callback '%s'", pin, callback
+        )
+
+        if edge in (InterruptEdge.BOTH, InterruptEdge.RISING):
+            self._pins[pin].when_activated = partial(callback, True)
+        if edge in (InterruptEdge.BOTH, InterruptEdge.FALLING):
+            self._pins[pin].when_deactivated = partial(callback, False)
+        self.interrupt_edges[pin] = edge
+
+    def get_interrupt_value(self, pin: PinType, *args: Any, **kwargs: Any) -> bool:
+        return cast(bool, args[0])


### PR DESCRIPTION
This PR adds a new gpio module "gpiozero" which uses https://github.com/gpiozero/gpiozero as backend.

gpiozero itself can use different pin_factories [Documentation](https://gpiozero.readthedocs.io/en/stable/api_pins.html)
and has multiple [input](https://gpiozero.readthedocs.io/en/stable/api_input.html) and [output](https://gpiozero.readthedocs.io/en/stable/api_output.html) devices.
All subclasses of InputDevice and OutputDevice can be used by specifying them in the "class"-config attribute.
Additional arguments can be given in the "kwargs" section for the input/output.
e.g.:
```yaml
digital_inputs:
  - name: motion
    module: gpiozero
    pin: 21
    interrupt: both
    class: MotionSensor
    kwargs:
      queue_len: 80
      threshold: 0.2
```

**Known Issues**
gpiozero calls cleanup() of RPi.GPIO and "raspberrypi" too, which causes one of them to fail.