### PR TITLE
Refactor

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
       
     steps:
       - uses: actions/checkout@v2

--- a/mqtt_io/events.py
+++ b/mqtt_io/events.py
@@ -8,6 +8,7 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import Any, Callable, Coroutine, Dict, List, Optional, Type
 
+from .tasks import TransientTaskManager
 from .utils import create_unawaited_task_threadsafe
 
 _LOG = logging.getLogger(__name__)
@@ -83,7 +84,7 @@ class EventBus:
     def __init__(
         self,
         loop: asyncio.AbstractEventLoop,
-        transient_tasks: List["asyncio.Task[Any]"],
+        transient_tasks: "TransientTaskManager",
     ):
         self._loop = loop
         self._transient_tasks = transient_tasks

--- a/mqtt_io/events.py
+++ b/mqtt_io/events.py
@@ -84,7 +84,7 @@ class EventBus:
     def __init__(
         self,
         loop: asyncio.AbstractEventLoop,
-        transient_tasks: "TransientTaskManager",
+        transient_tasks: TransientTaskManager,
     ):
         self._loop = loop
         self._transient_tasks = transient_tasks

--- a/mqtt_io/gpio.py
+++ b/mqtt_io/gpio.py
@@ -1,0 +1,553 @@
+"""
+Provides "StreamIo" which handles reading and writing to gpio-pins, interrupts on that pins, ...
+"""
+import asyncio
+import logging
+import threading
+from functools import partial
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
+
+from .config import (
+    validate_and_normalise_digital_input_config,
+    validate_and_normalise_digital_output_config,
+)
+from .constants import (
+    INPUT_TOPIC,
+    MQTT_SUB_PRIORITY,
+    OUTPUT_TOPIC,
+    SET_OFF_MS_SUFFIX,
+    SET_ON_MS_SUFFIX,
+    SET_SUFFIX,
+)
+from .events import (
+    DigitalInputChangedEvent,
+    DigitalOutputChangedEvent,
+)
+from .helpers import output_name_from_topic, _init_module
+from .modules.gpio import GenericGPIO, InterruptEdge, InterruptSupport, PinDirection
+from .types import ConfigType, PinType
+from .utils import PriorityCoro, create_unawaited_task_threadsafe
+
+if TYPE_CHECKING:
+    # pylint: disable=cyclic-import
+    from .server import MqttIo
+_LOG = logging.getLogger(__name__)
+
+
+# pylint: enable=duplicate-code
+# pylint: disable=too-many-lines
+
+
+class GPIOIo:  # pylint: disable=too-many-instance-attributes
+    """
+    Handles GPIO-Modules
+    """
+
+    def __init__(self, config: ConfigType, server: "MqttIo") -> None:
+        self.config = config
+        self.server = server
+
+        self.gpio_configs: Dict[str, ConfigType] = {}
+        self.digital_input_configs: Dict[str, ConfigType] = {}
+        self.digital_output_configs: Dict[str, ConfigType] = {}
+        self.gpio_modules: Dict[str, GenericGPIO] = {}
+
+        self.gpio_output_queues = (
+            {}
+        )  # type: Dict[str, asyncio.Queue[Tuple[ConfigType, str]]]
+        self.interrupt_locks: Dict[str, threading.Lock] = {}
+
+    def init(self) -> None:
+        """
+        Initializes modules, inputs and outputs.
+        """
+        self.init_gpio_modules()
+        self.init_digital_inputs()
+        self.init_digital_outputs()
+
+    def init_gpio_modules(self) -> None:
+        """
+        Initialise GPIO modules.
+        """
+        self.gpio_configs = {x["name"]: x for x in self.config["gpio_modules"]}
+        self.gpio_modules = {}
+        for gpio_config in self.config["gpio_modules"]:
+            self.gpio_modules[gpio_config["name"]] = _init_module(
+                gpio_config, "gpio", self.config["options"]["install_requirements"]
+            )
+
+    def init_digital_inputs(self) -> None:
+        """
+        Initialise all of the digital inputs by doing the following:
+        - Create a closure function to publish an MQTT message on DigitalInputchangedEvent
+        For each of the inputs:
+        - Set up the self.digital_input_configs dict
+        - Call the module's setup_pin() method
+        - Optionally start an async task that continuously polls the input for changes
+        - Optionally call the module's setup_interrupt() method, with a software callback
+          if it's supported.
+        """
+
+        # Set up MQTT publish callback for input event.
+        # Needs to be a function, not a method, hence the closure function.
+        async def publish_callback(event: DigitalInputChangedEvent) -> None:
+            in_conf = self.digital_input_configs[event.input_name]
+            value = event.to_value != in_conf["inverted"]
+            val = in_conf["on_payload"] if value else in_conf["off_payload"]
+            self.server.new_publish_task(
+                event.input_name, in_conf["retain"], val.encode("utf8"), INPUT_TOPIC
+            )
+
+        self.server.event_bus.subscribe(DigitalInputChangedEvent, publish_callback)
+
+        for in_conf in self.config["digital_inputs"]:
+            gpio_module = self.gpio_modules[in_conf["module"]]
+            in_conf = validate_and_normalise_digital_input_config(in_conf, gpio_module)
+            self.digital_input_configs[in_conf["name"]] = in_conf
+
+            gpio_module.setup_pin_internal(PinDirection.INPUT, in_conf)
+
+            interrupt = in_conf.get("interrupt")
+            interrupt_for = in_conf.get("interrupt_for")
+
+            # Only start the poller task if this _isn't_ set up with an interrupt, or if
+            # it _is_ an interrupt, but it's used for triggering remote interrupts.
+            if interrupt is None or (
+                    interrupt_for and in_conf["poll_when_interrupt_for"]
+            ):
+                self.server.transient_task_queue.add_task(
+                    self.server.loop.create_task(
+                        partial(self.digital_input_poller, gpio_module, in_conf)()
+                    )
+                )
+
+            if interrupt:
+                edge = {
+                    "rising": InterruptEdge.RISING,
+                    "falling": InterruptEdge.FALLING,
+                    "both": InterruptEdge.BOTH,
+                }[interrupt]
+                callback = None
+                if gpio_module.INTERRUPT_SUPPORT & InterruptSupport.SOFTWARE_CALLBACK:
+                    self.interrupt_locks[in_conf["name"]] = threading.Lock()
+                    # If it's a software callback interrupt, then supply
+                    # partial(self.interrupt_callback, module, in_conf["pin"])
+                    # as the callback.
+                    callback = partial(
+                        self.interrupt_callback, gpio_module, in_conf["pin"]
+                    )
+                gpio_module.setup_interrupt_internal(
+                    in_conf["pin"], edge, in_conf, callback=callback
+                )
+
+    def init_digital_outputs(self) -> None:
+        """
+        Initializes all outputs.
+        """
+        server = self.server
+
+        # Set up MQTT publish callback for output event
+        async def publish_callback(event: DigitalOutputChangedEvent) -> None:
+            out_conf = self.digital_output_configs[event.output_name]
+            val = out_conf["on_payload"] if event.to_value else out_conf["off_payload"]
+            server.new_publish_task(
+                event.output_name, out_conf["retain"], val.encode('utf8'), "output"
+            )
+
+        server.event_bus.subscribe(DigitalOutputChangedEvent, publish_callback)
+
+        for out_conf in self.config["digital_outputs"]:
+            gpio_module = self.gpio_modules[out_conf["module"]]
+            out_conf = validate_and_normalise_digital_output_config(out_conf, gpio_module)
+            self.digital_output_configs[out_conf["name"]] = out_conf
+
+            gpio_module.setup_pin_internal(PinDirection.OUTPUT, out_conf)
+
+            # Create queues for each module with an output
+            if out_conf["module"] not in self.gpio_output_queues:
+                async def create_digital_output_queue(
+                        out_conf: ConfigType = out_conf,
+                ) -> None:
+                    """
+                    Create digital output queue on the right loop.
+                    """
+                    queue = asyncio.Queue()  # type: asyncio.Queue[Tuple[ConfigType, str]]
+                    self.gpio_output_queues[out_conf["module"]] = queue
+
+                server.loop.run_until_complete(create_digital_output_queue())
+
+                # Use partial to avoid late binding closure
+                server.transient_task_queue.add_task(
+                    server.loop.create_task(
+                        partial(
+                            self.digital_output_loop,
+                            gpio_module,
+                            self.gpio_output_queues[out_conf["module"]],
+                        )()
+                    )
+                )
+
+            # Add tasks to subscribe to outputs when MQTT is initialised
+            topics = []
+            for suffix in (SET_SUFFIX, SET_ON_MS_SUFFIX, SET_OFF_MS_SUFFIX):
+                topics.append(
+                    "/".join(
+                        (
+                            self.config["mqtt"]["topic_prefix"],
+                            OUTPUT_TOPIC,
+                            out_conf["name"],
+                            suffix,
+                        )
+                    )
+                )
+            server.mqtt_task_queue.put_nowait(
+                PriorityCoro(server.mqtt_subscribe(topics), MQTT_SUB_PRIORITY)
+            )
+
+            # Fire DigitalOutputChangedEvents for initial values of outputs if required
+            if out_conf["publish_initial"]:
+                server.event_bus.fire(
+                    DigitalOutputChangedEvent(
+                        out_conf["name"],
+                        out_conf["initial"]
+                        == ("low" if out_conf["inverted"] else "high"),
+                    )
+                )
+
+    async def _handle_digital_input_value(
+            self,
+            in_conf: ConfigType,
+            value: bool,
+            last_value: Optional[bool],
+    ) -> None:
+        """
+        Handles values read from a digital input.
+
+        Fires a DigitalInputchangedEvent when it changes.
+
+        This function also helps maintain the working state of pins which are configured
+        as interrupts for other pins by checking if it's in the 'triggered' state. This
+        could mean that the interrupt callback code didn't fire when the pin changed
+        state. If that happens, you can end up in a deadlock where the pin remains in that
+        state until the remote interrupt is 'handled', which would be never, unless this
+        loop polls the 'triggered' value and calls the interupt handling code itself.
+
+        If the interrupt lock is not acquired, then it means that the interrupt is already
+        being handled, so we can check again on the next poll.
+        """
+        if value != last_value:
+            _LOG.info("Digital input '%s' value changed to %s", in_conf["name"], value)
+            self.server.event_bus.fire(
+                DigitalInputChangedEvent(in_conf["name"], last_value, value)
+            )
+        # If the value is now the same as the 'interrupt' value (falling, rising)
+        # and we're a remote interrupt then just trigger the remote interrupt
+        interrupt = in_conf.get("interrupt")
+        interrupt_for = in_conf.get("interrupt_for")
+        if not interrupt or not interrupt_for:
+            return
+        if not any(
+                (
+                        interrupt == "rising" and value,
+                        interrupt == "falling" and not value,
+                        # Doesn't work for 'both' because there's no one 'triggered' state
+                        # to check if we're stuck in.
+                        # interrupt == "both",
+                )
+        ):
+            return
+        interrupt_lock = self.interrupt_locks[in_conf["name"]]
+        if not interrupt_lock.acquire(blocking=False):
+            _LOG.debug(
+                (
+                    "Polled an interrupt value on pin '%s', but we're "
+                    "not triggering the remote interrupt because we're "
+                    "already handling it."
+                ),
+                in_conf["name"],
+            )
+            return
+        _LOG.debug(
+            "Polled value of %s on '%s' triggered remote interrupt",
+            value,
+            in_conf["name"],
+        )
+        self.handle_remote_interrupt(interrupt_for, interrupt_lock)
+
+    async def digital_input_poller(
+            self, module: GenericGPIO, in_conf: ConfigType
+    ) -> None:
+        """
+        Polls a single digital input for changes and calls the handler function when it's
+        been read.
+        """
+        last_value: Optional[bool] = None
+        while True:
+            value = await module.async_get_pin(in_conf["pin"])
+            await self._handle_digital_input_value(in_conf, value, last_value)
+            last_value = value
+            await asyncio.sleep(in_conf["poll_interval"])
+
+    def interrupt_callback(
+            self,
+            module: GenericGPIO,
+            pin: PinType,
+            *args: Any,
+            **kwargs: Any,
+    ) -> None:
+        """
+        This function is passed in to any GPIO library that provides software callbacks
+        called on interrupt. It's passed to the GPIO library's interrupt setup function
+        with its 'module' and 'pin' parameters already filled by partial(), so that
+        any *args and **kwargs supplied by the GPIO library will get passed directly
+        back to our GPIO module's get_interrupt_value() method.
+
+        If the pin is configured as a remote interrupt for another pin or pins, then the
+        execution, along with the interrupt lock is handed off to
+        self.handle_remote_interrupt(), instead of getting the pin value, firing the
+        DigitalInputChangedEvent and unlocking the interrupt lock.
+
+        This can potentially be called from any thread.
+        """
+        pin_name = module.pin_configs[pin]["name"]
+        if not self.server.running.is_set():
+            # Not yet ready to handle interrupts
+            _LOG.warning(
+                "Ignored interrupt from pin %r as we're not fully initialised", pin_name
+            )
+            return
+        interrupt_lock = self.interrupt_locks[pin_name]
+        if not interrupt_lock.acquire(blocking=False):
+            # This will only happen when the pin is configured with interrupt_for, as we
+            # release the lock locally otherwise.
+            # Hopefully it won't happen at all, but if we miss this interrupt then
+            # the poller will notice that the interrupt is triggered and it'll trigger
+            # the handling of the remote interrupt anyway, once this lock has been
+            # released when the remote interrupt handling tasks have all finished.
+            _LOG.warning(
+                (
+                    "Ignoring interrupt on pin '%s' because we're already busy "
+                    "processing one."
+                ),
+                pin_name,
+            )
+            return
+        remote_interrupt_for_pin_names: List[str] = []
+        try:
+            _LOG.info("Handling interrupt callback on pin '%s'", pin_name)
+            remote_interrupt_for_pin_names = module.remote_interrupt_for(pin)
+
+            if remote_interrupt_for_pin_names:
+                _LOG.debug("Interrupt on '%s' triggered remote interrupt.", pin_name)
+                self.handle_remote_interrupt(
+                    remote_interrupt_for_pin_names, interrupt_lock
+                )
+                return
+            _LOG.debug("Interrupt is for the '%s' pin itself", pin_name)
+            value = module.get_interrupt_value(pin, *args, **kwargs)
+            self.server.event_bus.fire(DigitalInputChangedEvent(pin_name, None, value))
+        finally:
+            if not remote_interrupt_for_pin_names:
+                interrupt_lock.release()
+
+    def handle_remote_interrupt(
+            self, pin_names: List[str], interrupt_lock: threading.Lock
+    ) -> None:
+        """
+        Adds tasks to the event loop to go off and get the values for the pin(s) which have
+        triggered a remote pin's interrupt logic.
+
+        The pin_names are organised by module, then a task is created to pass the list of
+        pins to get values for to the module that handles them, and fire a
+        DigitalInputChangedEvent for each of the pin values.
+
+        Once all of these tasks have completed, the interrupt lock is released.
+        """
+        # IDEA: Possible implementations -@flyte at 30/01/2021, 16:09:35
+        # Does the interrupt_for module say that its interrupt pin will be held low
+        # until the interrupt register is read, or does it just pulse its interrupt
+        # pin?
+        _LOG.debug("Interrupt is for pins: '%s'", "', '".join(pin_names))
+        remote_modules_and_pins: Dict[GenericGPIO, List[PinType]] = {}
+        for remote_pin_name in pin_names:
+            in_conf = self.digital_input_configs[remote_pin_name]
+            remote_module = self.gpio_modules[in_conf["module"]]
+            remote_modules_and_pins.setdefault(remote_module, []).append(in_conf["pin"])
+
+        remote_interrupt_tasks = []
+        for remote_module, pins in remote_modules_and_pins.items():
+
+            async def handle_remote_interrupt_task(
+                    remote_module: GenericGPIO = remote_module, pins: List[PinType] = pins
+            ) -> None:
+                """
+                Ask the GPIO module to fetch the values of the specified pins, because
+                they caused an interrupt on another module's pin, presumably because
+                the module's interrupt line was connected to it.
+
+                Fire a DigitalInputChangedEvent for each of the pins' values returned
+                because we don't really know if they changed or not.
+                """
+                interrupt_values = await remote_module.get_interrupt_values_remote(pins)
+                for pin, value in interrupt_values.items():
+                    remote_pin_name = remote_module.pin_configs[pin]["name"]
+                    self.server.event_bus.fire(
+                        DigitalInputChangedEvent(remote_pin_name, None, value)
+                    )
+
+            remote_interrupt_tasks.append(handle_remote_interrupt_task())
+
+        async def await_remote_interrupts() -> None:
+            """
+            Await all of the remote interrupt tasks so that we can release the interrupt
+            lock afterwards.
+            """
+            try:
+                await asyncio.gather(*remote_interrupt_tasks)
+            finally:
+                interrupt_lock.release()
+
+        create_unawaited_task_threadsafe(
+            self.server.loop, self.server.transient_task_queue, await_remote_interrupts()
+        )
+
+    async def handle_digital_output_msg(self, topic: str, payload: str) -> None:
+        """
+        Handle an MQTT message that intends to set a digital output's state.
+        """
+        topic_prefix: str = self.config["mqtt"]["topic_prefix"]
+        try:
+            output_name = output_name_from_topic(topic, topic_prefix, OUTPUT_TOPIC)
+        except ValueError as exc:
+            _LOG.warning("Unable to parse digital output name from topic: %s", exc)
+            return
+        try:
+            out_conf = self.digital_output_configs[output_name]
+        except KeyError:
+            _LOG.warning("No digital output config found named %r", output_name)
+            return
+        try:
+            module = self.gpio_modules[out_conf["module"]]
+        except KeyError:
+            _LOG.warning("No GPIO module config found named %r", out_conf["module"])
+            return
+        if topic.endswith("/%s" % SET_SUFFIX):
+            # This is a message to set a digital output to a given value
+            self.gpio_output_queues[out_conf["module"]].put_nowait((out_conf, payload))
+        else:
+            # This must be a set_on_ms or set_off_ms topic
+            desired_value = topic.endswith("/%s" % SET_ON_MS_SUFFIX)
+
+            async def set_ms() -> None:
+                """
+                Create this task to directly set the outputs, as we don't want to tie up
+                the set_digital_output loop. Creating a bespoke task for the job is the
+                simplest and most effective way of leveraging the asyncio framework.
+                """
+                try:
+                    secs = float(payload) / 1000
+                except ValueError:
+                    _LOG.warning(
+                        "Unable to parse ms value as float from payload %r", payload
+                    )
+                    return
+                _LOG.info(
+                    "Turning output '%s' %s for %s second(s)",
+                    out_conf["name"],
+                    "on" if desired_value else "off",
+                    secs,
+                )
+                await self.set_digital_output(module, out_conf, desired_value)
+                await asyncio.sleep(secs)
+                _LOG.info(
+                    "Turning output '%s' %s after %s second(s) elapsed",
+                    out_conf["name"],
+                    "off" if desired_value else "on",
+                    secs,
+                )
+                await self.set_digital_output(module, out_conf, not desired_value)
+
+            task = self.server.loop.create_task(set_ms())
+            self.server.transient_task_queue.add_task(task)
+
+    async def set_digital_output(
+            self, module: GenericGPIO, output_config: ConfigType, value: bool
+    ) -> None:
+        """
+        Set a digital output, taking into account whether it's configured
+        to be inverted.
+        """
+        set_value = value != output_config["inverted"]
+        await module.async_set_pin(output_config["pin"], set_value)
+        _LOG.info(
+            "Digital output '%s' set to %s (%s)",
+            output_config["name"],
+            set_value,
+            "on" if value else "off",
+        )
+        self.server.event_bus.fire(DigitalOutputChangedEvent(output_config["name"], value))
+
+    async def digital_output_loop(
+            self, module: GenericGPIO, queue: "asyncio.Queue[Tuple[ConfigType, str]]"
+    ) -> None:
+        """
+        Handle digital output MQTT messages for a specific GPIO module.
+        An instance of this loop will be created for each individual GPIO module so that
+        when messages come in via MQTT, we don't have to wait for some other module's
+        action to complete before carrying out this one.
+
+        It may seem like we should use this loop to handle /set_on_ms and /set_off_ms
+        messages, but it's actually better that we don't, since any timed stuff would
+        hold up /set messages that need to take place immediately.
+        """
+        while True:
+            out_conf, payload = await queue.get()
+            if payload not in (out_conf["on_payload"], out_conf["off_payload"]):
+                _LOG.warning(
+                    "'%s' is not a valid payload for output %s. Only '%s' and '%s' are allowed.",
+                    payload,
+                    out_conf["name"],
+                    out_conf["on_payload"],
+                    out_conf["off_payload"],
+                )
+                continue
+
+            value = payload == out_conf["on_payload"]
+            await self.set_digital_output(module, out_conf, value)
+
+            try:
+                msec = out_conf["timed_set_ms"]
+            except KeyError:
+                continue
+
+            async def reset_timer(out_conf: ConfigType = out_conf) -> None:
+                """
+                Reset the output to the opposite value after x ms.
+                """
+                await asyncio.sleep(msec / 1000.0)
+                _LOG.info(
+                    (
+                        "Setting digital output '%s' back to its previous value after "
+                        "configured 'timed_set_ms' delay of %sms"
+                    ),
+                    out_conf["name"],
+                    msec,
+                )
+                await self.set_digital_output(module, out_conf, not value)
+
+            task = self.server.loop.create_task(reset_timer())
+            self.server.transient_task_queue.add_task(task)
+
+    def cleanup(self) -> None:
+        """
+        Cleans up all modules
+        """
+        for module in self.gpio_modules.values():
+            _LOG.debug("Running cleanup on module %s", module)
+            try:
+                module.cleanup()
+            except Exception:  # pylint: disable=broad-except
+                _LOG.exception(
+                    "Exception while cleaning up GPIO module %s",
+                    module,
+                )

--- a/mqtt_io/helpers.py
+++ b/mqtt_io/helpers.py
@@ -1,0 +1,87 @@
+"""
+Helpers
+"""
+import logging
+import re
+from importlib import import_module
+from typing import Any, Dict, Type, Union, overload
+
+from typing_extensions import Literal
+
+from .config import (
+    get_main_schema_section,
+    validate_and_normalise_config,
+)
+from .constants import (
+    MODULE_CLASS_NAMES,
+    MODULE_IMPORT_PATH,
+)
+from .modules import install_missing_module_requirements
+from .modules.gpio import GenericGPIO
+from .modules.sensor import GenericSensor
+from .modules.stream import GenericStream
+
+_LOG = logging.getLogger(__name__)
+
+
+@overload
+def _init_module(
+        module_config: Dict[str, Dict[str, Any]],
+        module_type: Literal["gpio"],
+        install_requirements: bool,
+) -> GenericGPIO:
+    ...  # pragma: no cover
+
+
+@overload
+def _init_module(
+        module_config: Dict[str, Dict[str, Any]],
+        module_type: Literal["sensor"],
+        install_requirements: bool,
+) -> GenericSensor:
+    ...  # pragma: no cover
+
+
+@overload
+def _init_module(
+        module_config: Dict[str, Dict[str, Any]],
+        module_type: Literal["stream"],
+        install_requirements: bool,
+) -> GenericStream:
+    ...  # pragma: no cover
+
+
+def _init_module(
+        module_config: Dict[str, Dict[str, Any]], module_type: str, install_requirements: bool
+) -> Union[GenericGPIO, GenericSensor, GenericStream]:
+    """
+    Initialise a GPIO module by:
+    - Importing it
+    - Validating its config
+    - Installing any missing requirements for it
+    - Instantiating its class
+    """
+    module = import_module(
+        "%s.%s.%s" % (MODULE_IMPORT_PATH, module_type, module_config["module"])
+    )
+    # Doesn't need to be a deep copy because we're not mutating the base rules
+    module_schema = get_main_schema_section(f"{module_type}_modules")
+    # Add the module's config schema to the base schema
+    module_schema.update(getattr(module, "CONFIG_SCHEMA", {}))
+    module_config = validate_and_normalise_config(module_config, module_schema)
+    if install_requirements:
+        install_missing_module_requirements(module)
+    module_class: Type[Union[GenericGPIO, GenericSensor, GenericStream]] = getattr(
+        module, MODULE_CLASS_NAMES[module_type]
+    )
+    return module_class(module_config)
+
+
+def output_name_from_topic(topic: str, prefix: str, topic_type: str) -> str:
+    """
+    Parses an MQTT topic and returns the name of the output that the message relates to.
+    """
+    match = re.match(f"^{prefix}/{topic_type}/(.+?)/.+$", topic)
+    if match is None:
+        raise ValueError("Topic %r does not adhere to expected structure" % topic)
+    return match.group(1)

--- a/mqtt_io/mqtt/__init__.py
+++ b/mqtt_io/mqtt/__init__.py
@@ -3,11 +3,15 @@ Abstraction layer for MQTT clients to enable easier switching out.
 """
 import abc
 import asyncio
+import logging
 import ssl
 from dataclasses import dataclass
 from enum import Enum, auto
 from importlib import import_module
 from typing import List, Optional, Tuple, Type
+
+
+_LOG = logging.getLogger(__name__)
 
 
 class MQTTProtocol(Enum):
@@ -38,6 +42,25 @@ class MQTTMessageSend(MQTTMessage):
 
     qos: int = 0
     retain: bool = False
+
+    def debug(self) -> None:
+        """
+        Simple helper to log some debug info about this message
+        """
+        if self.payload is None:
+            _LOG.debug("Publishing MQTT message on topic %r with no payload", self.topic)
+        else:
+            try:
+                payload_str = self.payload.decode("utf8")
+            except UnicodeDecodeError:
+                _LOG.debug(
+                    "Publishing MQTT message on topic %r with non-unicode payload",
+                    self.topic,
+                )
+            else:
+                _LOG.debug(
+                    "Publishing MQTT message on topic %r: %r", self.topic, payload_str
+                )
 
 
 @dataclass

--- a/mqtt_io/sensors.py
+++ b/mqtt_io/sensors.py
@@ -1,0 +1,135 @@
+"""
+Provides "SensorIo" which handles reading of sensor values
+"""
+import asyncio
+import logging
+from typing import Dict, TYPE_CHECKING
+
+import backoff  # type: ignore
+
+from .config import (
+    validate_and_normalise_sensor_input_config,
+)
+from .constants import (
+    SENSOR_TOPIC,
+)
+from .events import (
+    SensorReadEvent,
+)
+from .helpers import _init_module
+from .modules.sensor import GenericSensor
+from .types import ConfigType, SensorValueType
+
+if TYPE_CHECKING:
+    # pylint: disable=cyclic-import
+    from .server import MqttIo
+_LOG = logging.getLogger(__name__)
+
+
+# pylint: enable=duplicate-code
+# pylint: disable=too-many-lines
+
+# pylint: disable=too-few-public-methods
+
+class SensorIo:
+    """
+    Handles the modules for reading sensor values.
+    Normally part of an instance of MqttIo
+    """
+
+    def __init__(self, config: ConfigType, server: "MqttIo") -> None:
+        self.config = config
+        self.server = server
+        # Sensor
+        self.sensor_configs: Dict[str, ConfigType] = {}
+        self.sensor_input_configs: Dict[str, ConfigType] = {}
+        self.sensor_modules: Dict[str, GenericSensor] = {}
+
+    def init(self) -> None:
+        """
+        Initializes the modules and inputs.
+        """
+        self._init_sensor_modules()
+        self._init_sensor_inputs()
+
+    def _init_sensor_modules(self) -> None:
+        """
+        Initialise Sensor modules.
+        """
+        self.sensor_configs = {x["name"]: x for x in self.config["sensor_modules"]}
+        self.sensor_modules = {}
+        for sens_config in self.config["sensor_modules"]:
+            self.sensor_modules[sens_config["name"]] = _init_module(
+                sens_config, "sensor", self.config["options"]["install_requirements"]
+            )
+
+    def _init_sensor_inputs(self) -> None:
+        async def publish_sensor_callback(event: SensorReadEvent) -> None:
+            sens_conf = self.sensor_input_configs[event.sensor_name]
+            digits: int = sens_conf["digits"]
+            self.server.new_publish_task(
+                event.sensor_name, sens_conf["retain"],
+                f"{event.value:.{digits}f}".encode("utf8"),
+                SENSOR_TOPIC
+            )
+
+        self.server.event_bus.subscribe(SensorReadEvent, publish_sensor_callback)
+
+        for sens_conf in self.config["sensor_inputs"]:
+            sensor_module = self.sensor_modules[sens_conf["module"]]
+            sens_conf = validate_and_normalise_sensor_input_config(
+                sens_conf, sensor_module
+            )
+            self.sensor_input_configs[sens_conf["name"]] = sens_conf
+
+            sensor_module.setup_sensor(sens_conf)
+
+            # Use default args to the function to get around the late binding closures
+            async def poll_sensor(
+                    sensor_module: GenericSensor = sensor_module,
+                    sens_conf: ConfigType = sens_conf,
+            ) -> None:
+                @backoff.on_exception(  # type: ignore
+                    backoff.expo, Exception, max_time=sens_conf["interval"]
+                )
+                @backoff.on_predicate(  # type: ignore
+                    backoff.expo, lambda x: x is None, max_time=sens_conf["interval"]
+                )
+                async def get_sensor_value(
+                        sensor_module: GenericSensor = sensor_module,
+                        sens_conf: ConfigType = sens_conf,
+                ) -> SensorValueType:
+                    return await sensor_module.async_get_value(sens_conf)
+
+                while True:
+                    value = None
+                    try:
+                        value = await get_sensor_value()
+                    except Exception:  # pylint: disable=broad-except
+                        _LOG.exception(
+                            "Exception when retrieving value from sensor %r:",
+                            sens_conf["name"],
+                        )
+                    if value is not None:
+                        value = round(value, sens_conf["digits"])
+                        _LOG.info(
+                            "Read sensor '%s' value of %s", sens_conf["name"], value
+                        )
+                        self.server.event_bus.fire(SensorReadEvent(sens_conf["name"], value))
+                    await asyncio.sleep(sens_conf["interval"])
+
+            self.server.transient_task_queue.add_task(self.server.loop.create_task(poll_sensor()))
+
+    def cleanup(self) -> None:
+        """
+        Cleans up all modules
+        """
+        for module in self.sensor_modules.values():
+            _LOG.debug("Running cleanup on module %s", module)
+            try:
+                module.cleanup()
+            except Exception:  # pylint: disable=broad-except
+                _LOG.exception(
+                    "Exception while cleaning up sensor module %s",
+                    module,
+                )

--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -607,20 +607,7 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
         if self.mqtt is None:
             raise RuntimeError("MQTT client was None when trying to publish.")
 
-        if msg.payload is None:
-            _LOG.debug("Publishing MQTT message on topic %r with no payload", msg.topic)
-        else:
-            try:
-                payload_str = msg.payload.decode("utf8")
-            except UnicodeDecodeError:
-                _LOG.debug(
-                    "Publishing MQTT message on topic %r with non-unicode payload",
-                    msg.topic,
-                )
-            else:
-                _LOG.debug(
-                    "Publishing MQTT message on topic %r: %r", msg.topic, payload_str
-                )
+        msg.debug()
 
         await self.mqtt.publish(msg)
 

--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -366,6 +366,7 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
             except asyncio.CancelledError:
                 break
             except MQTTException:
+                self.mqtt = None
                 if reconnects_remaining is not None:
                     reconnect = reconnects_remaining > 0
                     reconnects_remaining -= 1
@@ -375,7 +376,6 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
                 break
 
             finally:
-                self.mqtt = None
                 _LOG.debug("Clearing events and cancelling 'critical_tasks'")
                 self.running.clear()
                 self.mqtt_connected.clear()

--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -10,57 +10,29 @@ and setting their values and data, connecting to MQTT and sending/receiving MQTT
 
 import asyncio
 import logging
-import re
 import signal as signals
 import threading
 from asyncio.queues import QueueEmpty
-from functools import partial
 from hashlib import sha1
-from importlib import import_module
-from typing import Any, Dict, List, Optional, Tuple, Type, Union, overload
+from typing import Any, Dict, List, Optional
 
-import backoff  # type: ignore
-from typing_extensions import Literal
-
-from .config import (
-    get_main_schema_section,
-    validate_and_normalise_config,
-    validate_and_normalise_digital_input_config,
-    validate_and_normalise_digital_output_config,
-    validate_and_normalise_sensor_input_config,
-)
 from .constants import (
-    INPUT_TOPIC,
-    MODULE_CLASS_NAMES,
-    MODULE_IMPORT_PATH,
     MQTT_ANNOUNCE_PRIORITY,
     MQTT_PUB_PRIORITY,
-    MQTT_SUB_PRIORITY,
-    OUTPUT_TOPIC,
     SEND_SUFFIX,
-    SENSOR_TOPIC,
     SET_OFF_MS_SUFFIX,
     SET_ON_MS_SUFFIX,
     SET_SUFFIX,
-    STREAM_TOPIC,
 )
 from .events import (
-    DigitalInputChangedEvent,
-    DigitalOutputChangedEvent,
     EventBus,
-    SensorReadEvent,
-    StreamDataReadEvent,
-    StreamDataSentEvent,
 )
+from .gpio import GPIOIo
 from .home_assistant import (
     hass_announce_digital_input,
     hass_announce_digital_output,
     hass_announce_sensor_input,
 )
-from .modules import install_missing_module_requirements
-from .modules.gpio import GenericGPIO, InterruptEdge, InterruptSupport, PinDirection
-from .modules.sensor import GenericSensor
-from .modules.stream import GenericStream
 from .mqtt import (
     AbstractMQTTClient,
     MQTTClientOptions,
@@ -69,772 +41,13 @@ from .mqtt import (
     MQTTTLSOptions,
     MQTTWill,
 )
+from .sensors import SensorIo
+from .stream import StreamIo
 from .tasks import TransientTaskManager
-from .types import ConfigType, PinType, SensorValueType
-from .utils import PriorityCoro, create_unawaited_task_threadsafe
+from .types import ConfigType
+from .utils import PriorityCoro
 
 _LOG = logging.getLogger(__name__)
-
-
-@overload
-def _init_module(
-    module_config: Dict[str, Dict[str, Any]],
-    module_type: Literal["gpio"],
-    install_requirements: bool,
-) -> GenericGPIO:
-    ...  # pragma: no cover
-
-
-@overload
-def _init_module(
-    module_config: Dict[str, Dict[str, Any]],
-    module_type: Literal["sensor"],
-    install_requirements: bool,
-) -> GenericSensor:
-    ...  # pragma: no cover
-
-
-@overload
-def _init_module(
-    module_config: Dict[str, Dict[str, Any]],
-    module_type: Literal["stream"],
-    install_requirements: bool,
-) -> GenericStream:
-    ...  # pragma: no cover
-
-
-def _init_module(
-    module_config: Dict[str, Dict[str, Any]], module_type: str, install_requirements: bool
-) -> Union[GenericGPIO, GenericSensor, GenericStream]:
-    """
-    Initialise a GPIO module by:
-    - Importing it
-    - Validating its config
-    - Installing any missing requirements for it
-    - Instantiating its class
-    """
-    module = import_module(
-        "%s.%s.%s" % (MODULE_IMPORT_PATH, module_type, module_config["module"])
-    )
-    # Doesn't need to be a deep copy because we're not mutating the base rules
-    module_schema = get_main_schema_section(f"{module_type}_modules")
-    # Add the module's config schema to the base schema
-    module_schema.update(getattr(module, "CONFIG_SCHEMA", {}))
-    module_config = validate_and_normalise_config(module_config, module_schema)
-    if install_requirements:
-        install_missing_module_requirements(module)
-    module_class: Type[Union[GenericGPIO, GenericSensor, GenericStream]] = getattr(
-        module, MODULE_CLASS_NAMES[module_type]
-    )
-    return module_class(module_config)
-
-
-def output_name_from_topic(topic: str, prefix: str, topic_type: str) -> str:
-    """
-    Parses an MQTT topic and returns the name of the output that the message relates to.
-    """
-    match = re.match(f"^{prefix}/{topic_type}/(.+?)/.+$", topic)
-    if match is None:
-        raise ValueError("Topic %r does not adhere to expected structure" % topic)
-    return match.group(1)
-
-
-class StreamIo:
-    def __init__(self, config, server: "MqttIo", ):
-        """
-        Initialise Stream modules.
-        """
-        self.server = server
-        # Stream
-        self.stream_configs: Dict[str, ConfigType] = {}
-        self.stream_modules: Dict[str, GenericStream] = {}
-        self.stream_output_queues = {}  # type: Dict[str, asyncio.Queue[bytes]]
-
-        self.config = config
-
-    async def main(self):
-        server = self.server
-        # TODO: Tasks pending completion -@flyte at 01/03/2021, 14:40:10
-        # Only publish if read: true and only subscribe if write: true
-
-        async def publish_stream_data_callback(event: StreamDataReadEvent) -> None:
-            stream_conf = self.stream_configs[event.stream_name]
-            server.new_publish_task(
-                stream_conf["name"], stream_conf["retain"], event.data, STREAM_TOPIC
-            )
-
-        server.event_bus.subscribe(StreamDataReadEvent, publish_stream_data_callback)
-
-        self.stream_configs = {x["name"]: x for x in self.config["stream_modules"]}
-        self.stream_modules = {}
-        sub_topics: List[str] = []
-        for stream_conf in self.config["stream_modules"]:
-            stream_module = _init_module(
-                stream_conf, "stream", self.config["options"]["install_requirements"]
-            )
-            self.stream_modules[stream_conf["name"]] = stream_module
-
-            server._transient_task_queue.add_task(
-                server.loop.create_task(self.stream_poller(stream_module, stream_conf))
-            )
-
-            """
-            Set up a stream output queue.
-            """
-            queue = asyncio.Queue()  # type: asyncio.Queue[bytes]
-            self.stream_output_queues[stream_conf["name"]] = queue
-
-            # Queue a stream output loop task
-            server._transient_task_queue.add_task(
-                self.loop.create_task(
-                    # Use partial to avoid late binding closure
-                    partial(
-                        self.stream_output_loop,
-                        stream_module,
-                        stream_conf,
-                        self.stream_output_queues[stream_conf["name"]],
-                    )()
-                )
-            )
-
-            sub_topics.append(
-                "/".join(
-                    (
-                        self.config["mqtt"]["topic_prefix"],
-                        STREAM_TOPIC,
-                        stream_conf["name"],
-                        SEND_SUFFIX,
-                    )
-                )
-            )
-
-        # Subscribe to stream send topics
-        if sub_topics:
-            server.mqtt_task_queue.put_nowait(
-                PriorityCoro(server._mqtt_subscribe(sub_topics), MQTT_SUB_PRIORITY)
-            )
-
-    async def stream_poller(self, module: GenericStream, stream_conf: ConfigType) -> None:
-        """
-        Poll a stream at a given interval and fire the StreamDataReadEvent with read data.
-        """
-        while True:
-            try:
-                data = await module.async_read()
-            except Exception:  # pylint: disable=broad-except
-                _LOG.exception(
-                    "Exception while polling stream '%s':", stream_conf["name"]
-                )
-            else:
-                if data is not None:
-                    self.server.event_bus.fire(StreamDataReadEvent(stream_conf["name"], data))
-            await asyncio.sleep(stream_conf["read_interval"])
-
-    async def stream_output_loop(
-            self,
-            module: GenericStream,
-            stream_conf: ConfigType,
-            queue: "asyncio.Queue[bytes]",
-    ) -> None:
-        """
-        Wait for data to appear on the queue, then send it to the stream.
-        """
-        while True:
-            data = await queue.get()
-            try:
-                await module.async_write(data)
-            except Exception:  # pylint: disable=broad-except
-                _LOG.exception(
-                    "Exception while sending data to stream '%s':", stream_conf["name"]
-                )
-            else:
-                self.server.event_bus.fire(StreamDataSentEvent(stream_conf["name"], data))
-
-    async def handle_stream_send_msg(self, topic: str, payload: bytes) -> None:
-        try:
-            stream_name = output_name_from_topic(
-                topic, self.config["mqtt"]["topic_prefix"], STREAM_TOPIC
-            )
-        except ValueError as exc:
-            _LOG.warning("Unable to parse stream name from topic: %s", exc)
-            return
-        try:
-            self.stream_output_queues[stream_name].put_nowait(payload)
-        except KeyError:
-            _LOG.warning("No stream output queue found named %r", stream_name)
-
-
-class SensorIo:
-    def __init__(self, config, server: "MqttIo"):
-        self.config = config
-        self.server = server
-        # Sensor
-        self.sensor_configs: Dict[str, ConfigType] = {}
-        self.sensor_input_configs: Dict[str, ConfigType] = {}
-        self.sensor_modules: Dict[str, GenericSensor] = {}
-
-    def init(self):
-        self._init_sensor_modules()
-        self._init_sensor_inputs()
-
-    def _init_sensor_modules(self) -> None:
-        """
-        Initialise Sensor modules.
-        """
-        self.sensor_configs = {x["name"]: x for x in self.config["sensor_modules"]}
-        self.sensor_modules = {}
-        for sens_config in self.config["sensor_modules"]:
-            self.sensor_modules[sens_config["name"]] = _init_module(
-                sens_config, "sensor", self.config["options"]["install_requirements"]
-            )
-
-    def _init_sensor_inputs(self) -> None:
-        async def publish_sensor_callback(event: SensorReadEvent) -> None:
-            sens_conf = self.sensor_input_configs[event.sensor_name]
-            digits: int = sens_conf["digits"]
-            self.new_publish_task(
-                event.sensor_name, sens_conf["retain"],
-                f"{event.value:.{digits}f}".encode("utf8"),
-                SENSOR_TOPIC
-            )
-
-        self.server.event_bus.subscribe(SensorReadEvent, publish_sensor_callback)
-
-        for sens_conf in self.config["sensor_inputs"]:
-            sensor_module = self.sensor_modules[sens_conf["module"]]
-            sens_conf = validate_and_normalise_sensor_input_config(
-                sens_conf, sensor_module
-            )
-            self.sensor_input_configs[sens_conf["name"]] = sens_conf
-
-            sensor_module.setup_sensor(sens_conf)
-
-            # Use default args to the function to get around the late binding closures
-            async def poll_sensor(
-                sensor_module: GenericSensor = sensor_module,
-                sens_conf: ConfigType = sens_conf,
-            ) -> None:
-                @backoff.on_exception(  # type: ignore
-                    backoff.expo, Exception, max_time=sens_conf["interval"]
-                )
-                @backoff.on_predicate(  # type: ignore
-                    backoff.expo, lambda x: x is None, max_time=sens_conf["interval"]
-                )
-                async def get_sensor_value(
-                    sensor_module: GenericSensor = sensor_module,
-                    sens_conf: ConfigType = sens_conf,
-                ) -> SensorValueType:
-                    return await sensor_module.async_get_value(sens_conf)
-
-                while True:
-                    value = None
-                    try:
-                        value = await get_sensor_value()
-                    except Exception:  # pylint: disable=broad-except
-                        _LOG.exception(
-                            "Exception when retrieving value from sensor %r:",
-                            sens_conf["name"],
-                        )
-                    if value is not None:
-                        value = round(value, sens_conf["digits"])
-                        _LOG.info(
-                            "Read sensor '%s' value of %s", sens_conf["name"], value
-                        )
-                        self.server.event_bus.fire(SensorReadEvent(sens_conf["name"], value))
-                    await asyncio.sleep(sens_conf["interval"])
-
-            self.server._transient_task_queue.add_task(self.server.loop.create_task(poll_sensor()))
-
-
-class GPIOIo:
-    def __init__(self, config, server: "MqttIo"):
-        self.config = config
-        self.server = server
-
-        self.gpio_configs: Dict[str, ConfigType] = {}
-        self.digital_input_configs: Dict[str, ConfigType] = {}
-        self.digital_output_configs: Dict[str, ConfigType] = {}
-        self.gpio_modules: Dict[str, GenericGPIO] = {}
-
-        self.gpio_output_queues = (
-            {}
-        )  # type: Dict[str, asyncio.Queue[Tuple[ConfigType, str]]]
-        self.interrupt_locks: Dict[str, threading.Lock] = {}
-
-    def init(self):
-        self._init_gpio_modules()
-        self._init_digital_inputs()
-        self._init_digital_outputs()
-
-    def _init_gpio_modules(self) -> None:
-        """
-        Initialise GPIO modules.
-        """
-        self.gpio_configs = {x["name"]: x for x in self.config["gpio_modules"]}
-        self.gpio_modules = {}
-        for gpio_config in self.config["gpio_modules"]:
-            self.gpio_modules[gpio_config["name"]] = _init_module(
-                gpio_config, "gpio", self.config["options"]["install_requirements"]
-            )
-
-    def _init_digital_inputs(self) -> None:
-        """
-        Initialise all of the digital inputs by doing the following:
-        - Create a closure function to publish an MQTT message on DigitalInputchangedEvent
-        For each of the inputs:
-        - Set up the self.digital_input_configs dict
-        - Call the module's setup_pin() method
-        - Optionally start an async task that continuously polls the input for changes
-        - Optionally call the module's setup_interrupt() method, with a software callback
-          if it's supported.
-        """
-        # Set up MQTT publish callback for input event.
-        # Needs to be a function, not a method, hence the closure function.
-        async def publish_callback(event: DigitalInputChangedEvent) -> None:
-            in_conf = self.digital_input_configs[event.input_name]
-            value = event.to_value != in_conf["inverted"]
-            val = in_conf["on_payload"] if value else in_conf["off_payload"]
-            self.server.new_publish_task(
-                event.input_name, in_conf["retain"], val.encode("utf8"), INPUT_TOPIC
-            )
-
-        self.server.event_bus.subscribe(DigitalInputChangedEvent, publish_callback)
-
-        for in_conf in self.config["digital_inputs"]:
-            gpio_module = self.gpio_modules[in_conf["module"]]
-            in_conf = validate_and_normalise_digital_input_config(in_conf, gpio_module)
-            self.digital_input_configs[in_conf["name"]] = in_conf
-
-            gpio_module.setup_pin_internal(PinDirection.INPUT, in_conf)
-
-            interrupt = in_conf.get("interrupt")
-            interrupt_for = in_conf.get("interrupt_for")
-
-            # Only start the poller task if this _isn't_ set up with an interrupt, or if
-            # it _is_ an interrupt, but it's used for triggering remote interrupts.
-            if interrupt is None or (
-                interrupt_for and in_conf["poll_when_interrupt_for"]
-            ):
-                self.server._transient_task_queue.add_task(
-                    self.server.loop.create_task(
-                        partial(self.digital_input_poller, gpio_module, in_conf)()
-                    )
-                )
-
-            if interrupt:
-                edge = {
-                    "rising": InterruptEdge.RISING,
-                    "falling": InterruptEdge.FALLING,
-                    "both": InterruptEdge.BOTH,
-                }[interrupt]
-                callback = None
-                if gpio_module.INTERRUPT_SUPPORT & InterruptSupport.SOFTWARE_CALLBACK:
-                    self.interrupt_locks[in_conf["name"]] = threading.Lock()
-                    # If it's a software callback interrupt, then supply
-                    # partial(self.interrupt_callback, module, in_conf["pin"])
-                    # as the callback.
-                    callback = partial(
-                        self.interrupt_callback, gpio_module, in_conf["pin"]
-                    )
-                gpio_module.setup_interrupt_internal(
-                    in_conf["pin"], edge, in_conf, callback=callback
-                )
-
-    def _init_digital_outputs(self) -> None:
-        server = self.server
-
-        # Set up MQTT publish callback for output event
-        async def publish_callback(event: DigitalOutputChangedEvent) -> None:
-            out_conf = self.digital_output_configs[event.output_name]
-            val = out_conf["on_payload"] if event.to_value else out_conf["off_payload"]
-            server.new_publish_task(
-                event.output_name, out_conf["retain"], val.encode('utf8'), "output"
-            )
-
-        server.event_bus.subscribe(DigitalOutputChangedEvent, publish_callback)
-
-        for out_conf in self.config["digital_outputs"]:
-            gpio_module = self.gpio_modules[out_conf["module"]]
-            out_conf = validate_and_normalise_digital_output_config(out_conf, gpio_module)
-            self.digital_output_configs[out_conf["name"]] = out_conf
-
-            gpio_module.setup_pin_internal(PinDirection.OUTPUT, out_conf)
-
-            # Create queues for each module with an output
-            if out_conf["module"] not in self.gpio_output_queues:
-
-                async def create_digital_output_queue(
-                    out_conf: ConfigType = out_conf,
-                ) -> None:
-                    """
-                    Create digital output queue on the right loop.
-                    """
-                    queue = asyncio.Queue()  # type: asyncio.Queue[Tuple[ConfigType, str]]
-                    self.gpio_output_queues[out_conf["module"]] = queue
-
-                server.loop.run_until_complete(create_digital_output_queue())
-
-                # Use partial to avoid late binding closure
-                server._transient_task_queue.add_task(
-                    server.loop.create_task(
-                        partial(
-                            self.digital_output_loop,
-                            gpio_module,
-                            self.gpio_output_queues[out_conf["module"]],
-                        )()
-                    )
-                )
-
-            # Add tasks to subscribe to outputs when MQTT is initialised
-            topics = []
-            for suffix in (SET_SUFFIX, SET_ON_MS_SUFFIX, SET_OFF_MS_SUFFIX):
-                topics.append(
-                    "/".join(
-                        (
-                            self.config["mqtt"]["topic_prefix"],
-                            OUTPUT_TOPIC,
-                            out_conf["name"],
-                            suffix,
-                        )
-                    )
-                )
-            server.mqtt_task_queue.put_nowait(
-                PriorityCoro(server._mqtt_subscribe(topics), MQTT_SUB_PRIORITY)
-            )
-
-            # Fire DigitalOutputChangedEvents for initial values of outputs if required
-            if out_conf["publish_initial"]:
-                server.event_bus.fire(
-                    DigitalOutputChangedEvent(
-                        out_conf["name"],
-                        out_conf["initial"]
-                        == ("low" if out_conf["inverted"] else "high"),
-                    )
-                )
-
-    async def _handle_digital_input_value(
-        self,
-        in_conf: ConfigType,
-        value: bool,
-        last_value: Optional[bool],
-    ) -> None:
-        """
-        Handles values read from a digital input.
-
-        Fires a DigitalInputchangedEvent when it changes.
-
-        This function also helps maintain the working state of pins which are configured
-        as interrupts for other pins by checking if it's in the 'triggered' state. This
-        could mean that the interrupt callback code didn't fire when the pin changed
-        state. If that happens, you can end up in a deadlock where the pin remains in that
-        state until the remote interrupt is 'handled', which would be never, unless this
-        loop polls the 'triggered' value and calls the interupt handling code itself.
-
-        If the interrupt lock is not acquired, then it means that the interrupt is already
-        being handled, so we can check again on the next poll.
-        """
-        if value != last_value:
-            _LOG.info("Digital input '%s' value changed to %s", in_conf["name"], value)
-            self.server.event_bus.fire(
-                DigitalInputChangedEvent(in_conf["name"], last_value, value)
-            )
-        # If the value is now the same as the 'interrupt' value (falling, rising)
-        # and we're a remote interrupt then just trigger the remote interrupt
-        interrupt = in_conf.get("interrupt")
-        interrupt_for = in_conf.get("interrupt_for")
-        if not interrupt or not interrupt_for:
-            return
-        if not any(
-            (
-                interrupt == "rising" and value,
-                interrupt == "falling" and not value,
-                # Doesn't work for 'both' because there's no one 'triggered' state
-                # to check if we're stuck in.
-                # interrupt == "both",
-            )
-        ):
-            return
-        interrupt_lock = self.interrupt_locks[in_conf["name"]]
-        if not interrupt_lock.acquire(blocking=False):
-            _LOG.debug(
-                (
-                    "Polled an interrupt value on pin '%s', but we're "
-                    "not triggering the remote interrupt because we're "
-                    "already handling it."
-                ),
-                in_conf["name"],
-            )
-            return
-        _LOG.debug(
-            "Polled value of %s on '%s' triggered remote interrupt",
-            value,
-            in_conf["name"],
-        )
-        self.handle_remote_interrupt(interrupt_for, interrupt_lock)
-
-    async def digital_input_poller(
-        self, module: GenericGPIO, in_conf: ConfigType
-    ) -> None:
-        """
-        Polls a single digital input for changes and calls the handler function when it's
-        been read.
-        """
-        last_value: Optional[bool] = None
-        while True:
-            value = await module.async_get_pin(in_conf["pin"])
-            await self._handle_digital_input_value(in_conf, value, last_value)
-            last_value = value
-            await asyncio.sleep(in_conf["poll_interval"])
-
-    def interrupt_callback(
-        self,
-        module: GenericGPIO,
-        pin: PinType,
-        *args: Any,
-        **kwargs: Any,
-    ) -> None:
-        """
-        This function is passed in to any GPIO library that provides software callbacks
-        called on interrupt. It's passed to the GPIO library's interrupt setup function
-        with its 'module' and 'pin' parameters already filled by partial(), so that
-        any *args and **kwargs supplied by the GPIO library will get passed directly
-        back to our GPIO module's get_interrupt_value() method.
-
-        If the pin is configured as a remote interrupt for another pin or pins, then the
-        execution, along with the interrupt lock is handed off to
-        self.handle_remote_interrupt(), instead of getting the pin value, firing the
-        DigitalInputChangedEvent and unlocking the interrupt lock.
-
-        This can potentially be called from any thread.
-        """
-        pin_name = module.pin_configs[pin]["name"]
-        if not self.server.running.is_set():
-            # Not yet ready to handle interrupts
-            _LOG.warning(
-                "Ignored interrupt from pin %r as we're not fully initialised", pin_name
-            )
-            return
-        interrupt_lock = self.interrupt_locks[pin_name]
-        if not interrupt_lock.acquire(blocking=False):
-            # This will only happen when the pin is configured with interrupt_for, as we
-            # release the lock locally otherwise.
-            # Hopefully it won't happen at all, but if we miss this interrupt then
-            # the poller will notice that the interrupt is triggered and it'll trigger
-            # the handling of the remote interrupt anyway, once this lock has been
-            # released when the remote interrupt handling tasks have all finished.
-            _LOG.warning(
-                (
-                    "Ignoring interrupt on pin '%s' because we're already busy "
-                    "processing one."
-                ),
-                pin_name,
-            )
-            return
-        remote_interrupt_for_pin_names: List[str] = []
-        try:
-            _LOG.info("Handling interrupt callback on pin '%s'", pin_name)
-            remote_interrupt_for_pin_names = module.remote_interrupt_for(pin)
-
-            if remote_interrupt_for_pin_names:
-                _LOG.debug("Interrupt on '%s' triggered remote interrupt.", pin_name)
-                self.handle_remote_interrupt(
-                    remote_interrupt_for_pin_names, interrupt_lock
-                )
-                return
-            _LOG.debug("Interrupt is for the '%s' pin itself", pin_name)
-            value = module.get_interrupt_value(pin, *args, **kwargs)
-            self.server.event_bus.fire(DigitalInputChangedEvent(pin_name, None, value))
-        finally:
-            if not remote_interrupt_for_pin_names:
-                interrupt_lock.release()
-
-    def handle_remote_interrupt(
-        self, pin_names: List[str], interrupt_lock: threading.Lock
-    ) -> None:
-        """
-        Adds tasks to the event loop to go off and get the values for the pin(s) which have
-        triggered a remote pin's interrupt logic.
-
-        The pin_names are organised by module, then a task is created to pass the list of
-        pins to get values for to the module that handles them, and fire a
-        DigitalInputChangedEvent for each of the pin values.
-
-        Once all of these tasks have completed, the interrupt lock is released.
-        """
-        # IDEA: Possible implementations -@flyte at 30/01/2021, 16:09:35
-        # Does the interrupt_for module say that its interrupt pin will be held low
-        # until the interrupt register is read, or does it just pulse its interrupt
-        # pin?
-        _LOG.debug("Interrupt is for pins: '%s'", "', '".join(pin_names))
-        remote_modules_and_pins: Dict[GenericGPIO, List[PinType]] = {}
-        for remote_pin_name in pin_names:
-            in_conf = self.digital_input_configs[remote_pin_name]
-            remote_module = self.gpio_modules[in_conf["module"]]
-            remote_modules_and_pins.setdefault(remote_module, []).append(in_conf["pin"])
-
-        remote_interrupt_tasks = []
-        for remote_module, pins in remote_modules_and_pins.items():
-
-            async def handle_remote_interrupt_task(
-                remote_module: GenericGPIO = remote_module, pins: List[PinType] = pins
-            ) -> None:
-                """
-                Ask the GPIO module to fetch the values of the specified pins, because
-                they caused an interrupt on another module's pin, presumably because
-                the module's interrupt line was connected to it.
-
-                Fire a DigitalInputChangedEvent for each of the pins' values returned
-                because we don't really know if they changed or not.
-                """
-                interrupt_values = await remote_module.get_interrupt_values_remote(pins)
-                for pin, value in interrupt_values.items():
-                    remote_pin_name = remote_module.pin_configs[pin]["name"]
-                    self.server.event_bus.fire(
-                        DigitalInputChangedEvent(remote_pin_name, None, value)
-                    )
-
-            remote_interrupt_tasks.append(handle_remote_interrupt_task())
-
-        async def await_remote_interrupts() -> None:
-            """
-            Await all of the remote interrupt tasks so that we can release the interrupt
-            lock afterwards.
-            """
-            try:
-                await asyncio.gather(*remote_interrupt_tasks)
-            finally:
-                interrupt_lock.release()
-
-        create_unawaited_task_threadsafe(
-            self.server.loop, self.server._transient_task_queue, await_remote_interrupts()
-        )
-
-    async def _handle_digital_output_msg(self, topic: str, payload: str) -> None:
-        """
-        Handle an MQTT message that intends to set a digital output's state.
-        """
-        topic_prefix: str = self.config["mqtt"]["topic_prefix"]
-        try:
-            output_name = output_name_from_topic(topic, topic_prefix, OUTPUT_TOPIC)
-        except ValueError as exc:
-            _LOG.warning("Unable to parse digital output name from topic: %s", exc)
-            return
-        try:
-            out_conf = self.digital_output_configs[output_name]
-        except KeyError:
-            _LOG.warning("No digital output config found named %r", output_name)
-            return
-        try:
-            module = self.gpio_modules[out_conf["module"]]
-        except KeyError:
-            _LOG.warning("No GPIO module config found named %r", out_conf["module"])
-            return
-        if topic.endswith("/%s" % SET_SUFFIX):
-            # This is a message to set a digital output to a given value
-            self.gpio_output_queues[out_conf["module"]].put_nowait((out_conf, payload))
-        else:
-            # This must be a set_on_ms or set_off_ms topic
-            desired_value = topic.endswith("/%s" % SET_ON_MS_SUFFIX)
-
-            async def set_ms() -> None:
-                """
-                Create this task to directly set the outputs, as we don't want to tie up
-                the set_digital_output loop. Creating a bespoke task for the job is the
-                simplest and most effective way of leveraging the asyncio framework.
-                """
-                try:
-                    secs = float(payload) / 1000
-                except ValueError:
-                    _LOG.warning(
-                        "Unable to parse ms value as float from payload %r", payload
-                    )
-                    return
-                _LOG.info(
-                    "Turning output '%s' %s for %s second(s)",
-                    out_conf["name"],
-                    "on" if desired_value else "off",
-                    secs,
-                )
-                await self.set_digital_output(module, out_conf, desired_value)
-                await asyncio.sleep(secs)
-                _LOG.info(
-                    "Turning output '%s' %s after %s second(s) elapsed",
-                    out_conf["name"],
-                    "off" if desired_value else "on",
-                    secs,
-                )
-                await self.set_digital_output(module, out_conf, not desired_value)
-
-            task = self.server.loop.create_task(set_ms())
-            self.server._transient_task_queue.add_task(task)
-
-    async def set_digital_output(
-        self, module: GenericGPIO, output_config: ConfigType, value: bool
-    ) -> None:
-        """
-        Set a digital output, taking into account whether it's configured
-        to be inverted.
-        """
-        set_value = value != output_config["inverted"]
-        await module.async_set_pin(output_config["pin"], set_value)
-        _LOG.info(
-            "Digital output '%s' set to %s (%s)",
-            output_config["name"],
-            set_value,
-            "on" if value else "off",
-        )
-        self.server.event_bus.fire(DigitalOutputChangedEvent(output_config["name"], value))
-
-    async def digital_output_loop(
-        self, module: GenericGPIO, queue: "asyncio.Queue[Tuple[ConfigType, str]]"
-    ) -> None:
-        """
-        Handle digital output MQTT messages for a specific GPIO module.
-        An instance of this loop will be created for each individual GPIO module so that
-        when messages come in via MQTT, we don't have to wait for some other module's
-        action to complete before carrying out this one.
-
-        It may seem like we should use this loop to handle /set_on_ms and /set_off_ms
-        messages, but it's actually better that we don't, since any timed stuff would
-        hold up /set messages that need to take place immediately.
-        """
-        while True:
-            out_conf, payload = await queue.get()
-            if payload not in (out_conf["on_payload"], out_conf["off_payload"]):
-                _LOG.warning(
-                    "'%s' is not a valid payload for output %s. Only '%s' and '%s' are allowed.",
-                    payload,
-                    out_conf["name"],
-                    out_conf["on_payload"],
-                    out_conf["off_payload"],
-                )
-                continue
-
-            value = payload == out_conf["on_payload"]
-            await self.set_digital_output(module, out_conf, value)
-
-            try:
-                msec = out_conf["timed_set_ms"]
-            except KeyError:
-                continue
-
-            async def reset_timer(out_conf: ConfigType = out_conf) -> None:
-                """
-                Reset the output to the opposite value after x ms.
-                """
-                await asyncio.sleep(msec / 1000.0)
-                _LOG.info(
-                    (
-                        "Setting digital output '%s' back to its previous value after "
-                        "configured 'timed_set_ms' delay of %sms"
-                    ),
-                    out_conf["name"],
-                    msec,
-                )
-                await self.set_digital_output(module, out_conf, not value)
-
-            task = self.server.loop.create_task(reset_timer())
-            self.server._transient_task_queue.add_task(task)
 
 
 class MqttIo:  # pylint: disable=too-many-instance-attributes
@@ -861,16 +74,14 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
 
         self.stream = StreamIo(config, self)
 
-
         self.loop = loop or asyncio.get_event_loop()
         self._main_task: Optional["asyncio.Task[None]"] = None
         self.critical_tasks: List["asyncio.Task[Any]"] = []
 
-        self._transient_task_queue: "TransientTaskManager" = TransientTaskManager()
+        self.transient_task_queue: "TransientTaskManager" = TransientTaskManager()
 
-        self.event_bus = EventBus(self.loop, self._transient_task_queue)
+        self.event_bus = EventBus(self.loop, self.transient_task_queue)
         self.mqtt: Optional[AbstractMQTTClient] = None
-
 
         self.mqtt_task_queue: "asyncio.PriorityQueue[PriorityCoro]"
         self.mqtt_connected: asyncio.Event
@@ -999,7 +210,7 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
                 PriorityCoro(self._mqtt_publish(msg), MQTT_ANNOUNCE_PRIORITY)
             )
 
-    async def _mqtt_subscribe(self, topics: List[str]) -> None:
+    async def mqtt_subscribe(self, topics: List[str]) -> None:
         """
         Subscribe to MQTT topics and output to log for each.
         """
@@ -1116,7 +327,7 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
             await self._handle_mqtt_msg(msg.topic, msg.payload)
 
     async def _remove_finished_transient_tasks(self) -> None:
-        await self._transient_task_queue.loop()
+        await self.transient_task_queue.loop()
 
     async def _main_loop(self) -> None:
         reconnect = True
@@ -1191,11 +402,9 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
 
             self.loop.add_signal_handler(sig, signal_handler)
 
-        self._init_gpio_modules()
-        self._init_digital_inputs()
-        self._init_digital_outputs()
-
+        self.gpio.init()
         self.sensor.init()
+        self.stream.init()
 
         self._main_task = self.loop.create_task(self._main_loop())
 
@@ -1205,17 +414,10 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
         finally:
             self.loop.close()
             _LOG.debug("Loop closed")
-            for mod in [self.gpio_modules, self.sensor.sensor_modules, self.stream.stream_modules]:
-                for module in mod.values():
-                    _LOG.debug("Running cleanup on module %s", module)
-                    try:
-                        module.cleanup()
-                    except Exception:  # pylint: disable=broad-except
-                        _LOG.exception(
-                            "Exception while cleaning up %s module %s",
-                            mod,
-                            module,
-                        )
+            self.sensor.cleanup()
+            self.stream.cleanup()
+            self.gpio.cleanup()
+
         _LOG.debug("run() complete")
 
     async def shutdown(self) -> None:
@@ -1268,16 +470,21 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
         """
         A list of running transient tasks.
         """
-        return self._transient_task_queue.tasks
+        return self.transient_task_queue.tasks
 
-    def _init_sensor_modules(self):
+    # Needed for testing - TODO: remove
+
+    def _init_sensor_modules(self) -> None:
+
         self.sensor.init()
 
-    def _init_gpio_modules(self):
-        self.gpio._init_gpio_modules()
+    def _init_gpio_modules(self) -> None:
 
-    def _init_digital_outputs(self):
-        self.gpio._init_digital_outputs()
+        self.gpio.init_gpio_modules()
 
-    def _init_digital_inputs(self):
-        self.gpio._init_digital_inputs()
+    def _init_digital_outputs(self) -> None:
+
+        self.gpio.init_digital_outputs()
+
+    def _init_digital_inputs(self) -> None:
+        self.gpio.init_digital_inputs()

--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -332,6 +332,7 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
     async def _main_loop(self) -> None:
         reconnect = True
         reconnect_delay = self.config["mqtt"]["reconnect_delay"]
+        reconnects_remaining = self.config["mqtt"]["reconnect_count"]
         while reconnect:
             try:
                 await self._connect_mqtt()
@@ -354,6 +355,8 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
                     await asyncio.gather(*self.critical_tasks)
                 except asyncio.CancelledError:
                     break
+                except MQTTException:
+                    raise
                 except Exception:  # pylint: disable=broad-except
                     _LOG.exception("Exception in critical task:")
             except asyncio.CancelledError:

--- a/mqtt_io/stream.py
+++ b/mqtt_io/stream.py
@@ -1,0 +1,175 @@
+"""
+Provides "StreamIo" which handles writing and reading streams.
+"""
+import asyncio
+import logging
+from functools import partial
+from typing import Dict, List, TYPE_CHECKING
+
+from .constants import (
+    MQTT_SUB_PRIORITY,
+    SEND_SUFFIX,
+    STREAM_TOPIC,
+)
+from .events import (
+    StreamDataReadEvent,
+    StreamDataSentEvent,
+)
+from .helpers import output_name_from_topic, _init_module
+from .modules.stream import GenericStream
+from .types import ConfigType
+from .utils import PriorityCoro
+if TYPE_CHECKING:
+    # pylint: disable=cyclic-import
+    from .server import MqttIo
+_LOG = logging.getLogger(__name__)
+
+
+# pylint: enable=duplicate-code
+# pylint: disable=too-many-lines
+
+class StreamIo:
+    """
+    Handles reading and writing to streams.
+    """
+    def __init__(self, config: ConfigType, server: "MqttIo", ) -> None:
+        """
+        Initialise Stream modules.
+        """
+        self.server = server
+        # Stream
+        self.stream_configs: Dict[str, ConfigType] = {}
+        self.stream_modules: Dict[str, GenericStream] = {}
+        self.stream_output_queues = {}  # type: Dict[str, asyncio.Queue[bytes]]
+
+        self.config = config
+
+    def init(self) -> None:
+        """
+        Initialize the modules and starts task for polling.
+        """
+        server = self.server
+
+        # TODO: Tasks pending completion -@flyte at 01/03/2021, 14:40:10
+        # Only publish if read: true and only subscribe if write: true
+
+        async def publish_stream_data_callback(event: StreamDataReadEvent) -> None:
+            stream_conf = self.stream_configs[event.stream_name]
+            server.new_publish_task(
+                stream_conf["name"], stream_conf["retain"], event.data, STREAM_TOPIC
+            )
+
+        server.event_bus.subscribe(StreamDataReadEvent, publish_stream_data_callback)
+
+        self.stream_configs = {x["name"]: x for x in self.config["stream_modules"]}
+        self.stream_modules = {}
+        sub_topics: List[str] = []
+        for stream_conf in self.config["stream_modules"]:
+            stream_module = _init_module(
+                stream_conf, "stream", self.config["options"]["install_requirements"]
+            )
+            self.stream_modules[stream_conf["name"]] = stream_module
+
+            server.transient_task_queue.add_task(
+                server.loop.create_task(self.stream_poller(stream_module, stream_conf))
+            )
+
+            # Set up a stream output queue.
+            queue = asyncio.Queue()  # type: asyncio.Queue[bytes]
+            self.stream_output_queues[stream_conf["name"]] = queue
+
+            # Queue a stream output loop task
+            server.transient_task_queue.add_task(
+                server.loop.create_task(
+                    # Use partial to avoid late binding closure
+                    partial(
+                        self.stream_output_loop,
+                        stream_module,
+                        stream_conf,
+                        self.stream_output_queues[stream_conf["name"]],
+                    )()
+                )
+            )
+
+            sub_topics.append(
+                "/".join(
+                    (
+                        self.config["mqtt"]["topic_prefix"],
+                        STREAM_TOPIC,
+                        stream_conf["name"],
+                        SEND_SUFFIX,
+                    )
+                )
+            )
+
+        # Subscribe to stream send topics
+        if sub_topics:
+            server.mqtt_task_queue.put_nowait(
+                PriorityCoro(server.mqtt_subscribe(sub_topics), MQTT_SUB_PRIORITY)
+            )
+
+    async def stream_poller(self, module: GenericStream, stream_conf: ConfigType) -> None:
+        """
+        Poll a stream at a given interval and fire the StreamDataReadEvent with read data.
+        """
+        while True:
+            try:
+                data = await module.async_read()
+            except Exception:  # pylint: disable=broad-except
+                _LOG.exception(
+                    "Exception while polling stream '%s':", stream_conf["name"]
+                )
+            else:
+                if data is not None:
+                    self.server.event_bus.fire(StreamDataReadEvent(stream_conf["name"], data))
+            await asyncio.sleep(stream_conf["read_interval"])
+
+    async def stream_output_loop(
+            self,
+            module: GenericStream,
+            stream_conf: ConfigType,
+            queue: "asyncio.Queue[bytes]",
+    ) -> None:
+        """
+        Wait for data to appear on the queue, then send it to the stream.
+        """
+        while True:
+            data = await queue.get()
+            try:
+                await module.async_write(data)
+            except Exception:  # pylint: disable=broad-except
+                _LOG.exception(
+                    "Exception while sending data to stream '%s':", stream_conf["name"]
+                )
+            else:
+                self.server.event_bus.fire(StreamDataSentEvent(stream_conf["name"], data))
+
+    async def handle_stream_send_msg(self, topic: str, payload: bytes) -> None:
+        """
+        Handles writing of messages to the stream.
+        """
+        try:
+            stream_name = output_name_from_topic(
+                topic, self.config["mqtt"]["topic_prefix"], STREAM_TOPIC
+            )
+        except ValueError as exc:
+            _LOG.warning("Unable to parse stream name from topic: %s", exc)
+            return
+        try:
+            self.stream_output_queues[stream_name].put_nowait(payload)
+        except KeyError:
+            _LOG.warning("No stream output queue found named %r", stream_name)
+
+    def cleanup(self) -> None:
+        """
+        Cleans up all modules
+        """
+        for module in self.stream_modules.values():
+            _LOG.debug("Running cleanup on module %s", module)
+            try:
+                module.cleanup()
+            except Exception:  # pylint: disable=broad-except
+                _LOG.exception(
+                    "Exception while cleaning up stream module %s",
+                    module,
+                )

--- a/mqtt_io/tasks.py
+++ b/mqtt_io/tasks.py
@@ -84,3 +84,4 @@ class TransientTaskManager:
         if self._shut_down:
             raise RuntimeError('Tried to add a new task to a stopping TransientTaskManager!')
         self.tasks.append(task)
+        self._event.set()

--- a/mqtt_io/tasks.py
+++ b/mqtt_io/tasks.py
@@ -48,7 +48,7 @@ class TransientTaskManager:
                     watch_task = asyncio.create_task(event.wait())
             try:
                 done, _ = await asyncio.wait(
-                    tasks + [cast(asyncio.Task[bool], watch_task)],
+                    tasks + [cast("asyncio.Task[bool]", watch_task)],
                     return_when=asyncio.FIRST_COMPLETED
                 )
             except asyncio.CancelledError:
@@ -56,7 +56,7 @@ class TransientTaskManager:
                 self._shut_down = True
                 for task in tasks:
                     task.cancel()
-
+                watch_task.cancel()
                 continue
             if watch_task in done:
                 watch_task = None

--- a/mqtt_io/tasks.py
+++ b/mqtt_io/tasks.py
@@ -59,10 +59,13 @@ class TransientTaskManager:
                 if watch_task:
                     watch_task.cancel()
                 continue
-            if watch_task in done:
-                watch_task = None
             for ready_task in done:
                 if ready_task is watch_task:
+                    try:
+                        await ready_task
+                    except asyncio.CancelledError:
+                        pass
+                    watch_task = None
                     continue
                 try:
                     await ready_task

--- a/mqtt_io/tasks.py
+++ b/mqtt_io/tasks.py
@@ -56,7 +56,8 @@ class TransientTaskManager:
                 self._shut_down = True
                 for task in tasks:
                     task.cancel()
-                watch_task.cancel()
+                if watch_task:
+                    watch_task.cancel()
                 continue
             if watch_task in done:
                 watch_task = None

--- a/mqtt_io/tasks.py
+++ b/mqtt_io/tasks.py
@@ -45,7 +45,7 @@ class TransientTaskManager:
             event.clear()
             if not self._shut_down:
                 if not watch_task:
-                    watch_task = asyncio.create_task(event.wait())
+                    watch_task = asyncio.get_event_loop().create_task(event.wait())
             try:
                 done, _ = await asyncio.wait(
                     tasks + [cast("asyncio.Task[bool]", watch_task)],

--- a/mqtt_io/tasks.py
+++ b/mqtt_io/tasks.py
@@ -1,0 +1,56 @@
+import asyncio
+import logging
+from typing import List, Optional
+
+_LOG = logging.getLogger(__name__)
+
+
+class TransientTaskManager:
+    def __init__(self):
+        self._ev: "Optional[asyncio.Event]" = None
+        self._shut_down = False
+        self.tasks: "List[asyncio.Task]" = []
+
+    @property
+    def _event(self) -> "asyncio.Event":
+        if self._ev is None:
+            self._ev = asyncio.Event()
+        return self._ev
+
+    async def loop(self):
+        tasks = self.tasks
+        # "watch_task" to wake up when there is a new task
+        watch_task = None
+        event = self._event
+        while True:
+            event.clear()
+            if not self._shut_down:
+                if not watch_task:
+                    watch_task = asyncio.create_task(event.wait())
+            try:
+                done, pending = await asyncio.wait(tasks + [watch_task], return_when=asyncio.FIRST_COMPLETED)
+            except asyncio.CancelledError:
+                # We got cancelled
+                self._shut_down = True
+                for t in tasks:
+                    t.cancel()
+                continue
+            if watch_task in done:
+                watch_task = None
+            for task in done:
+                if task is watch_task:
+                    continue
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:  # pylint: disable=broad-except
+                    _LOG.exception("Exception in transient task %r", task)
+                tasks.remove(task)
+
+    def add_task(self, task_or_coro):
+        if self._shut_down:
+            raise RuntimeError('Tried to add a new task to a stopping TransientTaskManager!')
+        if not asyncio.isfuture(task_or_coro):
+            task_or_coro = asyncio.create_task(task_or_coro)
+        self.tasks.append(task_or_coro)

--- a/mqtt_io/tests/features/module_gpio_runtime.feature
+++ b/mqtt_io/tests/features/module_gpio_runtime.feature
@@ -52,7 +52,7 @@ Feature: GPIO module runtime
         And we instantiate MqttIo
         And we initialise GPIO modules
         And we initialise digital inputs
-        And we mock handle_remote_interrupt on MqttIo
+        And we mock handle_remote_interrupt on GPIOIo
         And mock1 reads a value of false with a last value of true
         Then handle_remote_interrupt on MqttIo should be called with
             """
@@ -88,7 +88,7 @@ Feature: GPIO module runtime
         And we instantiate MqttIo
         And we initialise GPIO modules
         And we initialise digital inputs
-        And we mock handle_remote_interrupt on MqttIo
+        And we mock handle_remote_interrupt on GPIOIo
         And we lock interrupt lock for mock1
         And mock1 reads a value of false with a last value of true
         Then handle_remote_interrupt on MqttIo shouldn't be called
@@ -111,7 +111,7 @@ Feature: GPIO module runtime
         And we initialise GPIO modules
         And we initialise digital inputs
         # Mock this to stop the digital_input_poller from firing events too
-        And we mock _handle_digital_input_value on MqttIo
+        And we mock _handle_digital_input_value on GPIOIo
         And we mock _mqtt_publish on MqttIo
         And we fire a new DigitalInputChangedEvent event with
             """
@@ -142,7 +142,7 @@ Feature: GPIO module runtime
         And we initialise GPIO modules
         And we initialise digital inputs
         # Mock this to stop the digital_input_poller from firing events too
-        And we mock _handle_digital_input_value on MqttIo
+        And we mock _handle_digital_input_value on GPIOIo
         And we mock _mqtt_publish on MqttIo
         And we fire a new DigitalInputChangedEvent event from another thread with
             """
@@ -174,7 +174,7 @@ Feature: GPIO module runtime
         And we initialise GPIO modules
         And we initialise digital inputs
         # Mock this to stop the digital_input_poller from firing events too
-        And we mock _handle_digital_input_value on MqttIo
+        And we mock _handle_digital_input_value on GPIOIo
         And we mock _mqtt_publish on MqttIo
         And we fire a new DigitalInputChangedEvent event with
             """
@@ -205,7 +205,7 @@ Feature: GPIO module runtime
         And we initialise GPIO modules
         And we initialise digital inputs
         # Mock this to stop the digital_input_poller from firing events too
-        And we mock _handle_digital_input_value on MqttIo
+        And we mock _handle_digital_input_value on GPIOIo
         And we mock _mqtt_publish on MqttIo
         And we fire a new DigitalInputChangedEvent event with
             """
@@ -237,7 +237,7 @@ Feature: GPIO module runtime
         And we initialise GPIO modules
         And we initialise digital inputs
         # Mock this to stop the digital_input_poller from firing events too
-        And we mock _handle_digital_input_value on MqttIo
+        And we mock _handle_digital_input_value on GPIOIo
         And we mock _mqtt_publish on MqttIo
         And we fire a new DigitalInputChangedEvent event with
             """

--- a/mqtt_io/tests/features/server_init_gpio.feature
+++ b/mqtt_io/tests/features/server_init_gpio.feature
@@ -16,7 +16,7 @@ Feature: Tests for the successful initialisation of the GPIO aspects of the serv
         When we validate the main config
         And we instantiate MqttIo
         And we initialise GPIO modules
-        Then GPIO module mock should be initialised
+        Then gpio module mock should be initialised
         And GPIO module mock should have 1 call(s) to setup_module
         And GPIO config mock should contain
             """

--- a/mqtt_io/tests/features/steps/module_gpio.py
+++ b/mqtt_io/tests/features/steps/module_gpio.py
@@ -48,14 +48,14 @@ def get_coro(task: "asyncio.Task[Any]") -> Any:
 @then("GPIO module {module_name} should have a pin config for {pin_name}")
 def step(context: Any, module_name: str, pin_name: str) -> None:
     mqttio = context.data["mqttio"]
-    module = mqttio.gpio_modules[module_name]
+    module = mqttio.gpio.gpio_modules[module_name]
     assert pin_name in {x["name"] for x in module.pin_configs.values()}
 
 
 @then("GPIO module {module_name} should have a setup_pin() call for {pin_name}")  # type: ignore[no-redef]
 def step(context: Any, module_name: str, pin_name: str) -> None:
     mqttio = context.data["mqttio"]
-    module = mqttio.gpio_modules[module_name]
+    module = mqttio.gpio.gpio_modules[module_name]
     call_pin_names = {
         kwargs["pin_config"]["name"] for _, kwargs in module.setup_pin.call_args_list
     }
@@ -66,8 +66,8 @@ def step(context: Any, module_name: str, pin_name: str) -> None:
 def step(context: Any, pin_name: str, io_dir: str) -> None:
     assert io_dir in ("input", "output")
     mqttio = context.data["mqttio"]
-    io_conf = getattr(mqttio, f"digital_{io_dir}_configs")[pin_name]
-    module = mqttio.gpio_modules[io_conf["module"]]
+    io_conf = getattr(mqttio.gpio, f"digital_{io_dir}_configs")[pin_name]
+    module = mqttio.gpio.gpio_modules[io_conf["module"]]
     pin_dirs = {
         kwargs["pin_config"]["name"]: args[1]
         for args, kwargs in module.setup_pin.call_args_list
@@ -88,7 +88,7 @@ def step(
 ) -> None:
     assert should_shouldnt in ("should", "shouldn't")
     mqttio = context.data["mqttio"]
-    module = mqttio.gpio_modules[module_name]
+    module = mqttio.gpio.gpio_modules[module_name]
     relevant_call_args = None
     for call_args, _ in getattr(module, setup_func_name).call_args_list:  # type: ignore[attr-defined]
         if call_args[2]["name"] == pin_name:
@@ -139,7 +139,7 @@ def step(context: Any, is_isnt: str, pin_name: str):
 def step(context: Any, is_isnt: str, module_name: str):
     assert is_isnt in ("is", "isn't")
     mqttio = context.data["mqttio"]
-    module = mqttio.gpio_modules[module_name]
+    module = mqttio.gpio.gpio_modules[module_name]
     task_modules = {
         get_coro(task).cr_frame.f_locals["module"]
         for task in mqttio.transient_tasks
@@ -174,8 +174,8 @@ def step(context: Any, is_isnt: str, module_name: str):
 def step(context: Any, pin_name: str, should_shouldnt: str):
     assert should_shouldnt in ("should", "shouldn't")
     mqttio = context.data["mqttio"]
-    in_conf = mqttio.digital_input_configs[pin_name]
-    module = mqttio.gpio_modules[in_conf["module"]]
+    in_conf = mqttio.gpio.digital_input_configs[pin_name]
+    module = mqttio.gpio.gpio_modules[in_conf["module"]]
     is_remote_interrupt = module.remote_interrupt_for(in_conf["pin"])
     if should_shouldnt == "should":
         assert is_remote_interrupt
@@ -186,8 +186,8 @@ def step(context: Any, pin_name: str, should_shouldnt: str):
 @then("{pin_name} should be configured as a {direction_str} interrupt")  # type: ignore[no-redef]
 def step(context: Any, pin_name: str, direction_str: str):
     mqttio = context.data["mqttio"]
-    in_conf = mqttio.digital_input_configs[pin_name]
-    module = mqttio.gpio_modules[in_conf["module"]]
+    in_conf = mqttio.gpio.digital_input_configs[pin_name]
+    module = mqttio.gpio.gpio_modules[in_conf["module"]]
     direction = module.interrupt_edges[in_conf["pin"]]
     assert direction == getattr(InterruptEdge, direction_str.upper())
 
@@ -199,10 +199,10 @@ async def step(context: Any, pin_name: str, value_str: str, last_value_str: str)
     assert last_value_str in ("null", "true", "false")
     value_map = dict(true=True, false=False, null=None)
     mqttio: MqttIo = context.data["mqttio"]
-    in_conf = mqttio.digital_input_configs[pin_name]
+    in_conf = mqttio.gpio.digital_input_configs[pin_name]
     value = value_map[value_str]
     last_value = value_map[last_value_str]
-    await mqttio._handle_digital_input_value(in_conf, value, last_value)
+    await mqttio.gpio._handle_digital_input_value(in_conf, value, last_value)
 
 
 @when("we set digital output {pin_name} to {on_off}")  # type: ignore[no-redef]
@@ -210,6 +210,6 @@ async def step(context: Any, pin_name: str, value_str: str, last_value_str: str)
 async def step(context: Any, pin_name: str, on_off: str) -> None:
     assert on_off in ("on", "off")
     mqttio: MqttIo = context.data["mqttio"]
-    out_conf = mqttio.digital_output_configs[pin_name]
-    module = mqttio.gpio_modules[out_conf["module"]]
-    await mqttio.set_digital_output(module, out_conf, on_off == "on")
+    out_conf = mqttio.gpio.digital_output_configs[pin_name]
+    module = mqttio.gpio.gpio_modules[out_conf["module"]]
+    await mqttio.gpio.set_digital_output(module, out_conf, on_off == "on")

--- a/mqtt_io/tests/features/steps/server.py
+++ b/mqtt_io/tests/features/steps/server.py
@@ -128,13 +128,13 @@ def step(context: Any, method_name: str, should_shouldnt: str):
         mock.assert_not_called()
 
 
-@then("gpio module {name} should be initialised")
+@then("gpio module {name} should be initialised") # type: ignore[no-redef]
 def step(context: Any, name: str) -> None:
     mqttio = context.data["mqttio"]
     assert name in getattr(mqttio.gpio, f"gpio_modules")
 
 
-@then("sensor module {name} should be initialised")
+@then("sensor module {name} should be initialised") # type: ignore[no-redef]
 def step(context: Any, name: str) -> None:
     mqttio = context.data["mqttio"]
     assert name in getattr(mqttio.sensor, f"sensor_modules")

--- a/mqtt_io/tests/features/steps/server.py
+++ b/mqtt_io/tests/features/steps/server.py
@@ -6,8 +6,9 @@ from unittest.mock import Mock
 import yaml
 from behave import given, then, when  # type: ignore
 from behave.api.async_step import async_run_until_complete  # type: ignore
+
 from mqtt_io.exceptions import ConfigValidationFailed
-from mqtt_io.mqtt import MQTTMessage, MQTTMessageSend
+from mqtt_io.mqtt import MQTTMessageSend
 from mqtt_io.server import MqttIo
 
 try:
@@ -32,19 +33,31 @@ def step(context: Any, target: str) -> None:
         context.data["validation_error"] = exc
 
 
-@when("we mock {method_name} on MqttIo")  # type: ignore[no-redef]
-def step(context: Any, method_name: str) -> None:
+@when("we mock {method_name} on {mod}")  # type: ignore[no-redef]
+def step(context: Any, method_name: str, mod: str) -> None:
+
     mqttio: MqttIo = context.data["mqttio"]
-    mock = AsyncMock() if iscoroutinefunction(getattr(mqttio, method_name)) else Mock()
+    if mod == 'MqttIo':
+        obj = mqttio
+    elif mod == 'GPIOIo':
+        obj = mqttio.gpio
+    elif mod == 'SensorIo':
+        obj = mqttio.sensor
+    elif mod == 'StreamIo':
+        obj = mqttio.stream
+    else:
+        raise ValueError('Invalid module')
+
+    mock = AsyncMock() if iscoroutinefunction(getattr(obj, method_name)) else Mock()
     context.data["mocks"][f"mqttio.{method_name}"] = mock
-    setattr(mqttio, method_name, mock)
+    setattr(obj, method_name, mock)
 
 
 @when("we {lock_unlock} interrupt lock for {pin_name}")  # type: ignore[no-redef]
 def step(context: Any, lock_unlock: str, pin_name: str) -> None:
     assert lock_unlock in ("lock", "unlock")
     mqttio: MqttIo = context.data["mqttio"]
-    lock = mqttio.interrupt_locks[pin_name]
+    lock = mqttio.gpio.interrupt_locks[pin_name]
     locked = lock.locked()
     if lock_unlock == "lock":
         assert not locked, "Can't lock an already locked lock"
@@ -64,7 +77,7 @@ async def step(context: Any):
 def step(context: Any, locked_unlocked: str, pin_name: str) -> None:
     assert locked_unlocked in ("locked", "unlocked")
     mqttio: MqttIo = context.data["mqttio"]
-    lock = mqttio.interrupt_locks[pin_name]
+    lock = mqttio.gpio.interrupt_locks[pin_name]
     locked = lock.locked()
     assert locked if locked_unlocked == "locked" else not locked
 
@@ -115,23 +128,37 @@ def step(context: Any, method_name: str, should_shouldnt: str):
         mock.assert_not_called()
 
 
-@then("{module} module {name} should be initialised")  # type: ignore[no-redef]
-def step(context: Any, module: str, name: str) -> None:
+@then("gpio module {name} should be initialised")
+def step(context: Any, name: str) -> None:
     mqttio = context.data["mqttio"]
-    assert name in getattr(mqttio, f"{module.lower()}_modules")
+    assert name in getattr(mqttio.gpio, f"gpio_modules")
+
+
+@then("sensor module {name} should be initialised")
+def step(context: Any, name: str) -> None:
+    mqttio = context.data["mqttio"]
+    assert name in getattr(mqttio.sensor, f"sensor_modules")
 
 
 @then("{module} module {name} should have {count:d} call(s) to {attribute}")  # type: ignore[no-redef]
 def step(context: Any, module: str, name: str, count: int, attribute: str) -> None:
     mqttio = context.data["mqttio"]
-    module = getattr(mqttio, f"{module.lower()}_modules")[name]
+    module = getattr(getattr(mqttio, f"{module.lower()}"), f"{module.lower()}_modules")[name]
     assert getattr(module, attribute).call_count == count
 
 
 @then("{target} config {name} should exist")  # type: ignore[no-redef]
 def step(context: Any, target: str, name: str) -> None:
     mqttio = context.data["mqttio"]
-    assert getattr(mqttio, f"{target.lower().replace(' ', '_')}_configs")[name]
+    attr_name = f"{target.lower().replace(' ', '_')}_configs"
+    assert getattr(
+        mqttio, attr_name,
+        getattr(
+            mqttio.gpio, attr_name, getattr(
+                mqttio.sensor, attr_name, getattr(mqttio.stream, attr_name, None)
+            )
+        )
+    )[name]
 
 
 @then("{target} config {name} should contain")  # type: ignore[no-redef]
@@ -141,7 +168,10 @@ def step(context: Any, target: str, name: str) -> None:
         data, dict
     ), "Data passed to this step should be a YAML formatted dict"
     mqttio = context.data["mqttio"]
-    target_config = getattr(mqttio, f"{target.lower().replace(' ', '_')}_configs")[name]
+    target_config = getattr(
+        getattr(mqttio, f"{target.lower().replace(' ', '_')}"),
+        f"{target.lower().replace(' ', '_')}_configs"
+    )[name]
     for key, value in data.items():
         assert target_config[key] == value
 
@@ -152,8 +182,8 @@ def step(context: Any, module_name: str, should_shouldnt: str) -> None:
     mqttio = context.data["mqttio"]
     test = all(
         (
-            "mock" in mqttio.gpio_output_queues,
-            isinstance(mqttio.gpio_output_queues.get("mock"), asyncio.Queue),
+            "mock" in mqttio.gpio.gpio_output_queues,
+            isinstance(mqttio.gpio.gpio_output_queues.get("mock"), asyncio.Queue),
         )
     )
 

--- a/mqtt_io/utils.py
+++ b/mqtt_io/utils.py
@@ -2,7 +2,9 @@
 Utils for MQTT IO project.
 """
 import asyncio
-from typing import Any, Coroutine, List, Optional, cast
+from typing import Any, Coroutine, Optional, cast
+
+from mqtt_io.tasks import TransientTaskManager
 
 
 class PriorityCoro:
@@ -23,7 +25,7 @@ class PriorityCoro:
 
 def create_unawaited_task_threadsafe(
     loop: asyncio.AbstractEventLoop,
-    transient_tasks: List["asyncio.Task[Any]"],
+    transient_tasks: "TransientTaskManager",
     coro: Coroutine[Any, Any, None],
     task_future: Optional["asyncio.Future[asyncio.Task[Any]]"] = None,
 ) -> None:
@@ -33,7 +35,7 @@ def create_unawaited_task_threadsafe(
 
     def callback() -> None:
         task = loop.create_task(coro)
-        transient_tasks.append(task)
+        transient_tasks.add_task(task)
         if task_future is not None:
             task_future.set_result(task)
 

--- a/mqtt_io/utils.py
+++ b/mqtt_io/utils.py
@@ -25,7 +25,7 @@ class PriorityCoro:
 
 def create_unawaited_task_threadsafe(
     loop: asyncio.AbstractEventLoop,
-    transient_tasks: "TransientTaskManager",
+    transient_tasks: TransientTaskManager,
     coro: Coroutine[Any, Any, None],
     task_future: Optional["asyncio.Future[asyncio.Task[Any]]"] = None,
 ) -> None:


### PR DESCRIPTION
I've done some refactoring:
- I've put the handling of "transient_tasks" to separate class (named "TransientTaskManager")
The '_remove_finished_transient_tasks' had a bug: only tasks with exceptions were removed from the list - which caused the list grow indefinitely.

- I've removed some duplicate code in server.py
- the method asyncio.Task.all_tasks(), used in some tests, is deprecated and not available in 3.9+. The alternative asyncio.all_tasks() is available since 3.7. I've created a wrapper which is uses the right method depending on python-version, to continue support for 3.6
Now, the tests run on 3.9, so I've added the version to the github pipeline

- I've extracted three classes from MqttIo:  StreamIo, GPIOIo and SensorIO, which handle the related modules.
- The reconnection does now work correctly:
Previously, if the first connection attempt failed, 'reconnects_remaining' were not defined in the exception handler, causing a crash. 
If the connection failed later, the try-except around gather caught the mqtt-exception, logged it, but didn't reraise it, so the outer reconnect-counting did not apply.
- shutdown tried to send a "stopped"-message even if there was no connection.
