### PR TITLE
Digital Output: fix initial state inconsistency

### DIFF
--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -788,7 +788,6 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
         back to our GPIO module's get_interrupt_value() method.
 
         If the pin is configured as a remote interrupt for another pin or pins, then the
-        If the pin is configured as a remote interrupt for another pin or pins, then the
         execution, along with the interrupt lock is handed off to
         self.handle_remote_interrupt(), instead of getting the pin value, firing the
         DigitalInputChangedEvent and unlocking the interrupt lock.


### PR DESCRIPTION
1. Added logic to `gpiod` module to keep current state of the `digital_output` if no `initial` was set in config. 
For example, `raspberrypi` module has special value `-1` to handle this case, but `gpiod` does not.

2. Server `digital_output` initialization  - publish to MQTT current state if no `publish_initial` was set in config.