### PR TITLE
New DockerPi 4 Channel Relay GPIO module

### DIFF
--- a/mqtt_io/modules/gpio/dockerpi.py
+++ b/mqtt_io/modules/gpio/dockerpi.py
@@ -1,5 +1,5 @@
 """
-Dockerpi GPIO
+DockerPi 4 Channel Relay GPIO
 """
 from pi_mqtt_gpio.modules import GenericGPIO
 

--- a/mqtt_io/modules/gpio/dockerpi.py
+++ b/mqtt_io/modules/gpio/dockerpi.py
@@ -1,0 +1,32 @@
+from pi_mqtt_gpio.modules import GenericGPIO
+
+REQUIREMENTS = ("smbus",)
+
+CONFIG_SCHEMA = {
+    "i2c_bus_num": {"type": "integer", "required": True, "empty": False}, # 1
+    "dev_addr": {"type": "integer", "required": True, "empty": False}, # 0x10, 0x11, 0x12, 0x13
+}
+
+ON = 0xFF
+OFF = 0x00
+DIRECTIONS = None
+PULLUPS = None
+
+class GPIO(GenericGPIO):
+    """
+    Implementation of DockerPi 4 chanel relay.
+    """
+    def __init__(self, config):
+        import smbus
+        self.bus = smbus.SMBus(config["i2c_bus_num"])
+        self.address = config["dev_addr"]
+
+    def setup_pin(self, pin, direction, pullup, pin_config):
+        pass
+
+    def set_pin(self, pin, value):
+        """ Turn on/off relay number self.relay """
+        self.bus.write_byte_data(self.address, pin, value)
+
+    def cleanup(self):
+        self.bus.close()

--- a/mqtt_io/modules/gpio/dockerpi.py
+++ b/mqtt_io/modules/gpio/dockerpi.py
@@ -1,7 +1,7 @@
 """
 DockerPi 4 Channel Relay GPIO
 """
-from pi_mqtt_gpio.modules import GenericGPIO
+from . import GenericGPIO
 
 REQUIREMENTS = ("smbus",)
 

--- a/mqtt_io/modules/gpio/dockerpi.py
+++ b/mqtt_io/modules/gpio/dockerpi.py
@@ -2,8 +2,8 @@
 DockerPi 4 Channel Relay GPIO
 """
 from typing import Optional
-from ...types import ConfigType, PinType
 from mqtt_io.modules.gpio import GenericGPIO, PinDirection, PinPUD
+from ...types import ConfigType, PinType
 
 REQUIREMENTS = ("smbus",)
 
@@ -13,7 +13,7 @@ CONFIG_SCHEMA = {
         "required": True,
         "empty": False,
         "default": 1,
-    }, 
+    },
     "dev_addr": {
         "type": "integer",
         "required": True,
@@ -32,6 +32,7 @@ class GPIO(GenericGPIO):
     Implementation of DockerPi 4 chanel relay.
     """
     def setup_module(self) -> None:
+        # pylint: disable=import-outside-toplevel,import-error
         import smbus as gpio
         addr = self.config["dev_addr"]
         bus = self.config["i2c_bus_num"]

--- a/mqtt_io/modules/gpio/dockerpi.py
+++ b/mqtt_io/modules/gpio/dockerpi.py
@@ -1,17 +1,28 @@
 """
 DockerPi 4 Channel Relay GPIO
 """
+from typing import Optional
 from ...types import ConfigType, PinType
 from mqtt_io.modules.gpio import GenericGPIO, PinDirection, PinPUD
 
 REQUIREMENTS = ("smbus",)
 
 CONFIG_SCHEMA = {
-    "i2c_bus_num": {"type": "integer", "required": True, "empty": False}, # 1
-    "dev_addr": {"type": "integer", "required": True, "empty": False}, # 0x10, 0x11, 0x12, 0x13
+    "i2c_bus_num": {
+        "type": "integer",
+        "required": True,
+        "empty": False,
+        "default": 1,
+    }, 
+    "dev_addr": {
+        "type": "integer",
+        "required": True,
+        "empty": False,
+        "default": 0x11,
+    }, # 0x10, 0x11, 0x12, 0x13
 }
 
-ON = 0xFF
+ON = 0x01
 OFF = 0x00
 DIRECTIONS = None
 PULLUPS = None
@@ -21,9 +32,11 @@ class GPIO(GenericGPIO):
     Implementation of DockerPi 4 chanel relay.
     """
     def setup_module(self) -> None:
-        import smbus
-        self.bus = smbus.SMBus(config["i2c_bus_num"])
-        self.address = config["dev_addr"]
+        import smbus as gpio
+        addr = self.config["dev_addr"]
+        bus = self.config["i2c_bus_num"]
+        self.bus = gpio.SMBus(bus)
+        self.address = addr
 
     def setup_pin(
         self,
@@ -31,7 +44,16 @@ class GPIO(GenericGPIO):
         direction: PinDirection,
         pullup: PinPUD,
         pin_config: ConfigType,
+        initial: Optional[str] = None,
     ) -> None:
+        print(
+           "setup_pin(pin=%r, direction=%r, pullup=%r, pin_config=%r, initial=%r)"
+           % (pin, direction, pullup, pin_config, initial)
+        )
+        if initial == "high":
+            self.set_pin(pin, ON)
+        elif initial == "low":
+            self.set_pin(pin, OFF)
 
     def set_pin(self, pin: PinType, value: bool) -> None:
         """ Turn on/off relay number self.address """

--- a/mqtt_io/modules/gpio/dockerpi.py
+++ b/mqtt_io/modules/gpio/dockerpi.py
@@ -1,4 +1,3 @@
-
 """
 Dockerpi GPIO
 """

--- a/mqtt_io/modules/gpio/dockerpi.py
+++ b/mqtt_io/modules/gpio/dockerpi.py
@@ -1,3 +1,7 @@
+
+"""
+Dockerpi GPIO
+"""
 from pi_mqtt_gpio.modules import GenericGPIO
 
 REQUIREMENTS = ("smbus",)

--- a/mqtt_io/modules/gpio/dockerpi.py
+++ b/mqtt_io/modules/gpio/dockerpi.py
@@ -1,7 +1,8 @@
 """
 DockerPi 4 Channel Relay GPIO
 """
-from . import GenericGPIO
+from ...types import ConfigType, PinType
+from mqtt_io.modules.gpio import GenericGPIO, PinDirection, PinPUD
 
 REQUIREMENTS = ("smbus",)
 
@@ -19,17 +20,25 @@ class GPIO(GenericGPIO):
     """
     Implementation of DockerPi 4 chanel relay.
     """
-    def __init__(self, config):
+    def setup_module(self) -> None:
         import smbus
         self.bus = smbus.SMBus(config["i2c_bus_num"])
         self.address = config["dev_addr"]
 
-    def setup_pin(self, pin, direction, pullup, pin_config):
-        pass
+    def setup_pin(
+        self,
+        pin: PinType,
+        direction: PinDirection,
+        pullup: PinPUD,
+        pin_config: ConfigType,
+    ) -> None:
 
-    def set_pin(self, pin, value):
-        """ Turn on/off relay number self.relay """
+    def set_pin(self, pin: PinType, value: bool) -> None:
+        """ Turn on/off relay number self.address """
         self.bus.write_byte_data(self.address, pin, value)
 
-    def cleanup(self):
+    def get_pin(self, pin: PinType) -> bool:
+        return bool(self.bus.read_byte_data[self.address, pin])
+
+    def cleanup(self) -> None:
         self.bus.close()


### PR DESCRIPTION
Added a new GPIO module to support DockerPi 4 Channels Relay that mount on a raspberry pi