### PR TITLE
Fix reconnects_remaining referenced before assignment

### DIFF
--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -1153,9 +1153,11 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
     async def _main_loop(self) -> None:
         reconnect = True
         reconnect_delay = self.config["mqtt"]["reconnect_delay"]
+        reconnects_remaining = self.config["mqtt"]["reconnect_count"]
         while reconnect:
             try:
                 await self._connect_mqtt()
+                # Reset reconnects remaining once successful
                 reconnects_remaining = self.config["mqtt"]["reconnect_count"]
                 self.critical_tasks = [
                     self.loop.create_task(coro)


### PR DESCRIPTION
This pull request fixes the following bug I experienced:
```
UnboundLocalError: local variable 'reconnects_remaining' referenced before assignment
```

As you can see from the existing code, `reconnects_remaining` is defined in the `try` block, but referenced in the catch block.