### PR TITLE
Only create one instance of sensor_module for ADS1x15

### DIFF
--- a/mqtt_io/modules/sensor/ads1x15.py
+++ b/mqtt_io/modules/sensor/ads1x15.py
@@ -77,9 +77,7 @@ class Sensor(GenericSensor):
         )
 
         # Create single-ended input for each pin in config
-        self.channels = dict(
-            [(pin, AnalogIn(self.ads, pin)) for pin in self.config["pins"]]
-        )
+        self.channels = {pin: AnalogIn(self.ads, pin) for pin in self.config["pins"]}
 
     def get_value(self, sens_conf: ConfigType) -> SensorValueType:
         """

--- a/mqtt_io/modules/sensor/ads1x15.py
+++ b/mqtt_io/modules/sensor/ads1x15.py
@@ -1,7 +1,6 @@
 """
 ADS1x15 analog to digital converters
 """
-
 from typing import cast
 
 from ...types import CerberusSchemaType, ConfigType, SensorValueType
@@ -20,7 +19,7 @@ CONFIG_SCHEMA: CerberusSchemaType = {
         empty=False,
         allowed=SENSOR_TYPES,
     ),
-    "pin": dict(type="integer", required=True, empty=False, allowed=[0, 1, 2, 3]),
+    "pins": dict(type="list", required=True, empty=False, allowed=[0, 1, 2, 3]),
     "gain": dict(
         type="integer",
         required=False,
@@ -43,6 +42,13 @@ class Sensor(GenericSensor):
             empty=False,
             allowed=["value", "voltage"],
             default="value",
+        ),
+        "pin": dict(
+            type="integer",
+            required=True,
+            empty=False,
+            allowed=[0, 1, 2, 3],
+            default=0,
         ),
     }
 
@@ -70,15 +76,20 @@ class Sensor(GenericSensor):
             self.i2c, gain=self.config["gain"], address=self.config["chip_addr"]
         )
 
-        # Create single-ended input on channel 0
-        self.chan = AnalogIn(self.ads, self.config["pin"])
+        # Create single-ended input for each pin in config
+        self.channels = dict(
+            [(pin, AnalogIn(self.ads, pin)) for pin in self.config["pins"]]
+        )
 
     def get_value(self, sens_conf: ConfigType) -> SensorValueType:
         """
         Get the value or voltage from the sensor
         """
         sens_type = sens_conf["type"]
-        data = dict(value=self.chan.value, voltage=self.chan.voltage)
+        data = dict(
+            value=self.channels[sens_conf["pin"]].value,
+            voltage=self.channels[sens_conf["pin"]].voltage,
+        )
         return cast(
             float,
             data[sens_type],


### PR DESCRIPTION
Instead of requiring a separate `sensor_module` config section for each pin on an `ADS1x15`, this requires you to set the pins to use in a single module, and assigning the specific sensor pins in the `sensor_inputs` section--allowing the re-use of the `Sensor` class instance and preventing the issues seen in #254.

The `ads1x15` sensor class has been updated to create an analog channel for each pin assigned in the config, up to all 4 available channels. 

New config example:

```yaml
sensor_modules:
  - name: ads_0
    module: ads1x15
    type: ADS1115
    pins:
      - 0
      - 1

sensor_inputs:
  - name: voltage_channel_0
    module: ads_0
    type: voltage
    pin: 0
    interval: 2

  - name: voltage_channel_1
    module: ads_0
    type: voltage
    pin: 1
    interval: 2
```

Fixes #254.