### PR TITLE
Add DS18B20 example to docs

### DIFF
--- a/docs_src/config/reference/sensor_inputs/README.md
+++ b/docs_src/config/reference/sensor_inputs/README.md
@@ -27,6 +27,7 @@ sensor_modules:
 sensor_inputs:
   - name: workshop_temp
     module: dht
+    type: temperature
     interval: 30
 
   - name: workshop_humidity
@@ -134,6 +135,7 @@ Unlisted entries accepted: True
 sensor_inputs:
   - name: workshop_temp
     module: dht
+    type: temperature
     ha_discovery:
       name: Workshop Temperature
       device_class: temperature

--- a/docs_src/config/reference/sensor_inputs/README.md
+++ b/docs_src/config/reference/sensor_inputs/README.md
@@ -27,7 +27,6 @@ sensor_modules:
 sensor_inputs:
   - name: workshop_temp
     module: dht
-    type: temperature
     interval: 30
 
   - name: workshop_humidity
@@ -135,7 +134,6 @@ Unlisted entries accepted: True
 sensor_inputs:
   - name: workshop_temp
     module: dht
-    type: temperature
     ha_discovery:
       name: Workshop Temperature
       device_class: temperature

--- a/docs_src/config/reference/sensor_inputs/README.md
+++ b/docs_src/config/reference/sensor_inputs/README.md
@@ -24,6 +24,11 @@ sensor_modules:
     type: AM2302
     pin: 4
 
+  - name: ds
+    module: ds18b
+    type: DS18B20
+    address: 000803702e49
+
 sensor_inputs:
   - name: workshop_temp
     module: dht
@@ -34,6 +39,9 @@ sensor_inputs:
     module: dht
     type: humidity
     interval: 60
+
+  - name: outdoor_temp
+    module: ds
 ```
 
 ## sensor_inputs.* :id=sensor_inputs-star

--- a/docs_src/config/reference/sensor_inputs/README.md
+++ b/docs_src/config/reference/sensor_inputs/README.md
@@ -147,6 +147,7 @@ sensor_inputs:
     ha_discovery:
       name: Workshop Temperature
       device_class: temperature
+      unit_of_measurement: °C
 
   - name: workshop_humidity
     module: dht
@@ -154,6 +155,7 @@ sensor_inputs:
     ha_discovery:
       name: Workshop Humidity
       device_class: humidity
+      unit_of_measurement: %
 ```
 
 ### component :id=sensor_inputs-star-ha_discovery-component


### PR DESCRIPTION
I was getting 

```
mqtt_io.exceptions.ConfigValidationFailed: Config did not validate:
type:
- unknown field
```

error when setting up DS18B20, as it doesn't require setting the `type: temperature`. Therefore just enhancing the docs.