### PR TITLE
Fix use of "2 / 3" gain setting for ADS1x15

### DIFF
--- a/mqtt_io/modules/sensor/ads1x15.py
+++ b/mqtt_io/modules/sensor/ads1x15.py
@@ -21,10 +21,9 @@ CONFIG_SCHEMA: CerberusSchemaType = {
     ),
     "pins": dict(type="list", required=True, empty=False, allowed=[0, 1, 2, 3]),
     "gain": dict(
-        type="integer",
         required=False,
         empty=False,
-        allowed=[2 / 3, 1, 2, 4, 8, 16],
+        allowed=[0.6666666666666666, 1, 2, 4, 8, 16],
         default=1,
     ),
 }


### PR DESCRIPTION
Currently, if "2 / 3" is entered into the config file for gain, it will error out as it requires an integer.  In order to use this gain setting, we have to pass a float of 0.6666666666666666 to the adafruit library.