### PR TITLE
Implement keepalive loop as a coro to fix issue #282

### DIFF
--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -1048,6 +1048,14 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
             self.mqtt_task_queue.task_done()
 
     async def _mqtt_keep_alive_loop(self) -> None:
+        """
+        Publish a message on the status topic regularly to keep the connection alive.
+        This is a workaround for 2 different problems:
+        - keepalive was not implemented in early versions of asyncio_mqtt
+        - due to the way we receive messages asynchronously in our own queue we are not able
+          to capture the disconnected exception and trigger the reconnection. This publish call
+          will trigger the exception if the connection was lost and reconnect. (Issue #282)
+        """
         config: ConfigType = self.config["mqtt"]
         topic_prefix: str = config["topic_prefix"]
         if not self.mqtt_connected.is_set():
@@ -1060,16 +1068,13 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
                 while self.mqtt is None:
                     await asyncio.sleep(1)
                 continue
-            try:
-                await self.mqtt.publish(MQTTMessageSend(
-                            "/".join((topic_prefix, config["status_topic"])),
-                            config["status_payload_running"].encode("utf8"),
-                            qos=1,
-                            retain=True,
-                        ))
-                await asyncio.sleep(config["keepalive"])
-            except MQTTException:
-                raise
+            await self.mqtt.publish(MQTTMessageSend(
+                        "/".join((topic_prefix, config["status_topic"])),
+                        config["status_payload_running"].encode("utf8"),
+                        qos=1,
+                        retain=True,
+                    ))
+            await asyncio.sleep(config["keepalive"])
 
     async def _mqtt_rx_loop(self) -> None:
         if not self.mqtt_connected.is_set():


### PR DESCRIPTION
Due to the way the code consumes messages, we are not capturing the _on_disconnect Future from asyncio-mqtt. To avoid rewriting a lot of code I implemented a keep alive loop updating the status with a call to publish. This will capture the disconnected future and throw the exception to trigger reconnection. 

This fixes issue #282 