### PR TITLE
Sensor INA219: Use optional i2c_bus_num

### DIFF
--- a/mqtt_io/modules/sensor/ina219.py
+++ b/mqtt_io/modules/sensor/ina219.py
@@ -31,7 +31,7 @@ _LOG = logging.getLogger(__name__)
 REQUIREMENTS = ("pi-ina219",)
 CONFIG_SCHEMA: CerberusSchemaType = {
     "chip_addr": dict(type="integer", required=True),
-    "i2c_bus_num": dict(type="integer", required=False),
+    "i2c_bus_num": dict(type="integer", required=False, default=1),
     "shunt_ohms": dict(type="float", required=False, empty=False, default=0.1),
     "max_amps": dict(type="float", required=False, empty=False),
     "voltage_range": dict(

--- a/mqtt_io/modules/sensor/ina219.py
+++ b/mqtt_io/modules/sensor/ina219.py
@@ -11,6 +11,7 @@ INA219 DC current sensor
 # - gain (40, 80, 160 or 320) -> maximum shunt voltage (milli volt)
 # Optional:
 # - low_power: send ina219 to sleep between readings
+# - i2c_bus_num: if auto detection fails - like on Pi4
 
 # Output:
 # - power (in watt)
@@ -30,7 +31,8 @@ _LOG = logging.getLogger(__name__)
 REQUIREMENTS = ("pi-ina219",)
 CONFIG_SCHEMA: CerberusSchemaType = {
     "chip_addr": dict(type="integer", required=True),
-    "shunt_ohms": dict(type="float", required=False, empty=False, default=100),
+    "i2c_bus_num": dict(type="integer", required=False),
+    "shunt_ohms": dict(type="float", required=False, empty=False, default=0.1),
     "max_amps": dict(type="float", required=False, empty=False),
     "voltage_range": dict(
         type="integer", required=False, empty=False, allowed=[16, 32], default=32
@@ -71,6 +73,7 @@ class Sensor(GenericSensor):
             self.config["shunt_ohms"],
             max_expected_amps=self.config.get("max_amps"),
             address=self.config["chip_addr"],
+            busnum=self.config["i2c_bus_num"],
         )
 
         ## Configure ina sensor with range and gain from config or default


### PR DESCRIPTION
- Adds ability to set bus - needed for Raspberry 4 because autodetection fails on this board
- Sets default shunt_ohms to 0.1 (instead of 100) - the almost always used R100 has 0.1 Ohms, not 100 Ohms.