### PR TITLE
Fix applying mqtt.reconnect_count by reordering except clauses

### DIFF
--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -18,7 +18,7 @@ from functools import partial
 from hashlib import sha1
 from importlib import import_module
 from typing import Any, Dict, List, Optional, Tuple, Type, Union, overload
-from asyncio_mqtt.error import MqttCodeError
+from asyncio_mqtt.error import MqttCodeError # type: ignore
 
 import backoff  # type: ignore
 from typing_extensions import Literal


### PR DESCRIPTION
Reconnect_count is not applied on mqtt server disconnect because exception is caught by general except clause.
In consequence the MqttCodeError Exception doesnt reach the except clause to handle reconnect.
By these bugfix the except clauses are reordered, so that the reconnect_count is applied again correctly.