### PR TITLE
repeat subscribe when reconnected to MQTT broker

### DIFF
--- a/mqtt_io/events.py
+++ b/mqtt_io/events.py
@@ -74,6 +74,18 @@ class StreamDataSentEvent(Event):
     stream_name: str
     data: bytes
 
+@dataclass
+class StreamDataSubscribeEvent(Event):
+    """
+    Trigger MQTT subscribe
+    """
+
+@dataclass
+class DigitalSubscribeEvent(Event):
+    """
+    Trigger MQTT subscribe
+    """
+
 
 class EventBus:
     """

--- a/mqtt_io/mqtt/asyncio_mqtt.py
+++ b/mqtt_io/mqtt/asyncio_mqtt.py
@@ -94,7 +94,7 @@ class MQTTClient(AbstractMQTTClient):
             username=options.username,
             password=options.password,
             client_id=options.client_id,
-            keepalive=options.keepalive,
+            #keepalive=options.keepalive,
             tls_context=tls_context,
             protocol=protocol_map[options.protocol],
             will=will,

--- a/mqtt_io/mqtt/asyncio_mqtt.py
+++ b/mqtt_io/mqtt/asyncio_mqtt.py
@@ -26,8 +26,25 @@ Func = TypeVar("Func", bound=Callable[..., Any])
 
 
 def _map_exception(func: Func) -> Func:
+    """
+    Creates a decorator that wraps a function and maps any raised `MqttError` exception to a `MQTTException`.
+
+    :param func: The function to be wrapped.
+    :type func: Func
+    :return: The wrapped function.
+    :rtype: Func
+    """
     @wraps(func)
     async def inner(*args: Any, **kwargs: Any) -> Any:
+        """
+        Decorator for asynchronous functions that catches `MqttError` exceptions and raises `MQTTException` instead.
+
+        Parameters:
+            func (Callable): The function to be decorated.
+
+        Returns:
+            Callable: The decorated function.
+        """
         try:
             await func(*args, **kwargs)
         except MqttError as exc:
@@ -42,6 +59,15 @@ class MQTTClient(AbstractMQTTClient):
     """
 
     def __init__(self, options: MQTTClientOptions):
+        """
+        Initializes a new instance of the MQTTClient class.
+
+        Args:
+            options (MQTTClientOptions): The options for the MQTT client.
+
+        Returns:
+            None
+        """
         super().__init__(options)
         protocol_map = {
             MQTTProtocol.V31: paho.MQTTv31,
@@ -66,7 +92,7 @@ class MQTTClient(AbstractMQTTClient):
             username=options.username,
             password=options.password,
             client_id=options.client_id,
-            # keepalive=options.keepalive,  # This isn't implemented yet on 0.8.1
+            keepalive=options.keepalive,
             tls_context=tls_context,
             protocol=protocol_map[options.protocol],
             will=will,
@@ -76,10 +102,28 @@ class MQTTClient(AbstractMQTTClient):
 
     @_map_exception
     async def connect(self, timeout: int = 10) -> None:
+        """
+        Connects to the client asynchronously.
+
+        Args:
+            timeout (int): The timeout value in seconds (default: 10).
+
+        Returns:
+            None: This function does not return anything.
+        """
         await self._client.connect(timeout=timeout)
 
     @_map_exception
     async def disconnect(self) -> None:
+        """
+        This function is an asynchronous method that handles the disconnection of the client.
+        
+        Parameters:
+            self: The current instance of the class.
+            
+        Returns:
+            None
+        """
         try:
             await self._client.disconnect()
         except TimeoutError:
@@ -87,10 +131,33 @@ class MQTTClient(AbstractMQTTClient):
 
     @_map_exception
     async def subscribe(self, topics: List[Tuple[str, int]]) -> None:
+        """
+        Subscribe to the given list of topics.
+
+        Args:
+            topics (List[Tuple[str, int]]): A list of tuples representing the topics to subscribe to. 
+            Each tuple should contain a string representing the topic name and an integer representing the QoS level.
+
+        Returns:
+            None: This function does not return anything.
+
+        Raises:
+            Exception: If there is an error while subscribing to the topics.
+
+        """
         await self._client.subscribe(topics)
 
     @_map_exception
     async def publish(self, msg: MQTTMessageSend) -> None:
+        """
+        Publishes an MQTT message to the specified topic.
+
+        Args:
+            msg (MQTTMessageSend): The MQTT message to be published.
+
+        Returns:
+            None: This function does not return anything.
+        """
         await self._client.publish(
             topic=msg.topic, payload=msg.payload, qos=msg.qos, retain=msg.retain
         )
@@ -98,6 +165,17 @@ class MQTTClient(AbstractMQTTClient):
     def _on_message(
         self, client: paho.Client, userdata: Any, msg: paho.MQTTMessage
     ) -> None:
+        """
+        Callback function that is called when a message is received through MQTT.
+
+        Args:
+            client (paho.Client): The MQTT client instance.
+            userdata (Any): The user data associated with the client.
+            msg (paho.MQTTMessage): The received MQTT message.
+
+        Returns:
+            None: This function does not return anything.
+        """
         if self._message_queue is None:
             _LOG.warning("Discarding MQTT message because queue is not initialised")
             return
@@ -111,6 +189,12 @@ class MQTTClient(AbstractMQTTClient):
 
     @property
     def message_queue(self) -> "asyncio.Queue[MQTTMessage]":
+        """
+        Returns the message queue for receiving MQTT messages.
+        
+        :return: The message queue for receiving MQTT messages.
+        :rtype: asyncio.Queue[MQTTMessage]
+        """
         if self._message_queue is None:
             self._message_queue = asyncio.Queue(self._options.message_queue_size)
             # pylint: disable=protected-access

--- a/mqtt_io/mqtt/asyncio_mqtt.py
+++ b/mqtt_io/mqtt/asyncio_mqtt.py
@@ -27,7 +27,8 @@ Func = TypeVar("Func", bound=Callable[..., Any])
 
 def _map_exception(func: Func) -> Func:
     """
-    Creates a decorator that wraps a function and maps any raised `MqttError` exception to a `MQTTException`.
+    Creates a decorator that wraps a function and maps any raised `MqttError`
+    exception to a `MQTTException`.
 
     :param func: The function to be wrapped.
     :type func: Func
@@ -37,7 +38,8 @@ def _map_exception(func: Func) -> Func:
     @wraps(func)
     async def inner(*args: Any, **kwargs: Any) -> Any:
         """
-        Decorator for asynchronous functions that catches `MqttError` exceptions and raises `MQTTException` instead.
+        Decorator for asynchronous functions that catches `MqttError` exceptions
+        and raises `MQTTException` instead.
 
         Parameters:
             func (Callable): The function to be decorated.
@@ -117,10 +119,10 @@ class MQTTClient(AbstractMQTTClient):
     async def disconnect(self) -> None:
         """
         This function is an asynchronous method that handles the disconnection of the client.
-        
+
         Parameters:
             self: The current instance of the class.
-            
+
         Returns:
             None
         """
@@ -135,8 +137,10 @@ class MQTTClient(AbstractMQTTClient):
         Subscribe to the given list of topics.
 
         Args:
-            topics (List[Tuple[str, int]]): A list of tuples representing the topics to subscribe to. 
-            Each tuple should contain a string representing the topic name and an integer representing the QoS level.
+            topics (List[Tuple[str, int]]): A list of tuples representing the topics
+                to subscribe to.
+            Each tuple should contain a string representing the topic name and
+                an integer representing the QoS level.
 
         Returns:
             None: This function does not return anything.
@@ -191,7 +195,7 @@ class MQTTClient(AbstractMQTTClient):
     def message_queue(self) -> "asyncio.Queue[MQTTMessage]":
         """
         Returns the message queue for receiving MQTT messages.
-        
+
         :return: The message queue for receiving MQTT messages.
         :rtype: asyncio.Queue[MQTTMessage]
         """

--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -661,7 +661,8 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
                     A decorator that applies exponential backoff to the function `get_sensor_value`.
 
                     Parameters:
-                        sensor_module (GenericSensor): The sensor module to use for getting the sensor value.
+                        sensor_module (GenericSensor): The sensor module to use for getting
+                            the sensor value.
                         sens_conf (ConfigType): The configuration for the sensor.
 
                     Returns:
@@ -792,7 +793,7 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
 
         if msg.payload is None:
             _LOG.debug("Publishing MQTT message on topic %r with no payload", msg.topic)
-        elif isinstance(msg.payload, bytes) or isinstance(msg.payload, bytearray):
+        elif isinstance(msg.payload, (bytearray, bytes)):
             try:
                 payload = msg.payload.decode("utf8")
             except UnicodeDecodeError:

--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -154,7 +154,8 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
 
         Parameters:
             config (Dict[str, Any]): The configuration for the class.
-            loop (Optional[asyncio.AbstractEventLoop]): The event loop to use. If not provided, the default event loop will be used.
+            loop (Optional[asyncio.AbstractEventLoop]): The event loop to use.
+            If not provided, the default event loop will be used.
 
         Returns:
             None
@@ -212,10 +213,10 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
         """
         Initializes the MQTT configuration.
 
-        This function retrieves the MQTT configuration from the application's 
-        main configuration file and performs the necessary setup tasks. 
-        It sets the topic prefix for MQTT messages, replaces the '<ip>' placeholder 
-        in the topic prefix with the IP address of the 'wlan0' interface, 
+        This function retrieves the MQTT configuration from the application's
+        main configuration file and performs the necessary setup tasks.
+        It sets the topic prefix for MQTT messages, replaces the '<ip>' placeholder
+        in the topic prefix with the IP address of the 'wlan0' interface,
         generates a client ID if not provided, and configures TLS options if enabled.
 
         Parameters:
@@ -364,7 +365,7 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
                         )
                     )
                 )
-            
+
             if sub_topics:
                 self.mqtt_task_queue.put_nowait(
                     PriorityCoro(self._mqtt_subscribe(sub_topics), MQTT_SUB_PRIORITY)
@@ -453,17 +454,17 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
     def _init_digital_outputs(self) -> None:
         """
         Initializes the digital outputs.
-        
-        This function sets up the MQTT publish callback for the output event. 
-        It creates a digital output queue on the right loop for each module. 
-        It subscribes to outputs when MQTT is initialized. 
-        It also fires DigitalOutputChangedEvents for the initial values of 
-        outputs if required, and reads and publishes the actual pin state 
+
+        This function sets up the MQTT publish callback for the output event.
+        It creates a digital output queue on the right loop for each module.
+        It subscribes to outputs when MQTT is initialized.
+        It also fires DigitalOutputChangedEvents for the initial values of
+        outputs if required, and reads and publishes the actual pin state
         if no publish_initial is requested.
-        
+
         Parameters:
             None
-        
+
         Returns:
             None
         """
@@ -473,7 +474,8 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
             Publishes a callback function for the given DigitalOutputChangedEvent.
 
             Args:
-                event (DigitalOutputChangedEvent): The event object containing the details of the digital output change.
+                event (DigitalOutputChangedEvent): The event object containing the details
+                of the digital output change.
 
             Returns:
                 None
@@ -636,8 +638,10 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
                 Asynchronously polls a sensor to retrieve its value at regular intervals.
 
                 Args:
-                    sensor_module (Optional[GenericSensor]): The sensor module to use. Defaults to the sensor_module provided during function call.
-                    sens_conf (Optional[ConfigType]): The configuration for the sensor. Defaults to the sens_conf provided during function call.
+                    sensor_module (Optional[GenericSensor]): The sensor module to use.
+                    Defaults to the sensor_module provided during function call.
+                    sens_conf (Optional[ConfigType]): The configuration for the sensor.
+                    Defaults to the sens_conf provided during function call.
 
                 Returns:
                     None
@@ -655,11 +659,11 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
                 ) -> SensorValueType:
                     """
                     A decorator that applies exponential backoff to the function `get_sensor_value`.
-                    
+
                     Parameters:
                         sensor_module (GenericSensor): The sensor module to use for getting the sensor value.
                         sens_conf (ConfigType): The configuration for the sensor.
-                    
+
                     Returns:
                         SensorValueType: The value retrieved from the sensor.
                     """
@@ -769,7 +773,8 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
 
         Args:
             msg (MQTTMessageSend): The MQTT message to publish.
-            wait (bool, optional): Whether to wait for MQTT connection before publishing. Defaults to True.
+            wait (bool, optional): Whether to wait for MQTT connection before publishing.
+            Defaults to True.
 
         Raises:
             RuntimeError: If the MQTT client is None.
@@ -787,21 +792,21 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
 
         if msg.payload is None:
             _LOG.debug("Publishing MQTT message on topic %r with no payload", msg.topic)
-        elif type(msg.payload) == bytes or type(msg.payload) == bytearray:
-                try:
-                    payload = msg.payload.decode("utf8")
-                except UnicodeDecodeError:
-                    _LOG.debug(
-                        "Publishing MQTT message on topic %r with non-unicode payload",
-                        msg.topic,
-                    )
-                else:
-                    _LOG.debug(
-                        "Publishing MQTT message on topic %r: %r", msg.topic, payload
-                    )
+        elif isinstance(msg.payload, bytes) or isinstance(msg.payload, bytearray):
+            try:
+                payload = msg.payload.decode("utf8")
+            except UnicodeDecodeError:
+                _LOG.debug(
+                    "Publishing MQTT message on topic %r with non-unicode payload",
+                    msg.topic,
+                )
+            else:
+                _LOG.debug(
+                    "Publishing MQTT message on topic %r: %r", msg.topic, payload
+                )
         else:
             _LOG.debug(
-                f"Publishing MQTT message on topic {msg.topic}: {msg.payload}"
+                "Publishing MQTT message on topic %r: %r", msg.topic, payload
             )
 
         await self.mqtt.publish(msg)
@@ -1355,13 +1360,13 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
         """
         Asynchronous main loop function.
 
-        This function is responsible for running the main event loop of the MQTT client. 
-        It handles reconnecting to the MQTT broker if the connection is lost and 
+        This function is responsible for running the main event loop of the MQTT client.
+        It handles reconnecting to the MQTT broker if the connection is lost and
         manages the execution of critical tasks.
 
         Parameters:
             None
-        
+
         Returns:
             None
         """


### PR DESCRIPTION
Changes:

- Subscriptions to the MQTT broker are now repeated, when the mqtt-io client reconnnects to the broker after losing the connection. Before the change the subscriptions were lost.
- Exceptions, which occured when the connection to the broker was lost, are now caught. Instead error messages are logged.
- Added some comments for certain functions for better understanding of the functionality.

Closes #333 