### PR TITLE
docker: use a "slim" base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # when building multiarch using buildx, then try this:
 # https://github.com/docker/buildx/issues/495#issuecomment-761562905
 
-FROM python:3.8-buster AS base
+FROM python:3.8-slim-buster AS base
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
@@ -41,8 +41,8 @@ WORKDIR /home/mqtt_io
 
 COPY --from=requirements --chown=mqtt_io /home/mqtt_io/venv ./venv
 COPY --from=requirements /requirements.txt ./
-RUN venv/bin/python -m pip install --upgrade pip
-RUN venv/bin/pip install -r requirements.txt
+RUN venv/bin/python -m pip install --no-cache-dir --upgrade pip
+RUN venv/bin/pip install --no-cache-dir -r requirements.txt
 
 COPY --chown=mqtt_io mqtt_io mqtt_io
 


### PR DESCRIPTION
This tiny PR changes the docker base image from python:3.8-buster to python:3.8-slim-buster. This most likely has no functional difference (tested only on a raspberry pi with gpiod), and reduces the uncompressed image from 855MB to just 144MB (pretty shocking, not sure why such a huge difference).

It also adds `--no-cache-dir` to pip, which saves a tiny bit more.