### PR TITLE
Fix non-unique identifiers reporting to HA

### DIFF
--- a/mqtt_io/home_assistant.py
+++ b/mqtt_io/home_assistant.py
@@ -34,7 +34,7 @@ def get_common_config(
             device=dict(
                 manufacturer="MQTT IO",
                 model=f"v{VERSION}",
-                identifiers=["mqtt-io", mqtt_options.client_id],
+                identifiers=[mqtt_options.client_id],
                 name=disco_conf["name"],
             ),
         )


### PR DESCRIPTION
Delete identifier "mqtt-io" as it is not unique in situations with multiple instances of MQTT IO reporting to a single instance of HA. Only the unique identifier is needed. Otherwise, the multiple instances of MQTT IO appear as a single device to HA.