### PR TITLE
docker: slim image, use rustup, build deps only on armv7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,14 @@ jobs:
           TAG_NAME=${GITHUB_REF##*/}
           # Change slashes to hyphens
           TAG_NAME=${TAG_NAME//\//-}
-          docker buildx build --platform linux/arm/v7,linux/arm64/v8,linux/amd64 -t flyte/mqtt-io:${TAG_NAME} -t flyte/mqtt-io:latest --push --build-arg BUILDX_QEMU_ENV=true .
+          docker buildx build --platform linux/arm/v7,linux/arm64/v8,linux/amd64 -t flyte/mqtt-io:${TAG_NAME} -t flyte/mqtt-io:latest --push .
       - if: github.event_name == 'push'
         run: |
           # Remove prefix push
           TAG_NAME=${GITHUB_REF##*/}
           # Change slashes to hyphens
           TAG_NAME=${TAG_NAME//\//-}
-          docker buildx build --platform linux/arm/v7,linux/arm64/v8,linux/amd64 -t flyte/mqtt-io:${TAG_NAME} --push --build-arg BUILDX_QEMU_ENV=true .
+          docker buildx build --platform linux/arm/v7,linux/arm64/v8,linux/amd64 -t flyte/mqtt-io:${TAG_NAME} --push .
 
   generate_docs:
     name: Generate Documentation

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # when building multiarch using buildx, then try this:
 # https://github.com/docker/buildx/issues/495#issuecomment-761562905
 
-FROM python:3.8-buster AS base
+FROM python:3.8-slim-buster AS base
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
@@ -11,23 +11,21 @@ ENV LC_ALL C.UTF-8
 
 FROM base AS requirements
 
-ARG BUILDX_QEMU_ENV
-RUN apt-get update && \
-    apt-get install -y lsb-release rustc libssl-dev libffi-dev python3-venv && \
-    apt-get clean && \
-    rm -rf /var/lib/apt-/lists/*
+# On linux/arm/v7 the cryptography package has no binary wheel, so we need its build
+# dependencies. For rust, install the latest from rustup to avoid issues.
+ARG TARGETPLATFORM
+RUN if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then \
+        apt-get update && \
+        apt-get install -y lsb-release curl g++ pkg-config libssl-dev libffi-dev && \
+        \
+        (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y) \
+    fi
+ENV PATH="/root/.cargo/bin:${PATH}"
 
-# This nonsense is required for this reason:
-# https://github.com/JonasAlfredsson/docker-nginx-certbot/issues/30
-
-RUN pip install --no-cache-dir wheel setuptools-rust && \
-    if [ "${BUILDX_QEMU_ENV}" = "true" -a "$(getconf LONG_BIT)" = "32" ]; then \
-        pip install --no-cache-dir cryptography==3.3.2; \
-    fi && \
-    pip install --no-cache-dir poetry
 
 COPY pyproject.toml ./
-RUN poetry export -o /requirements.txt && \
+RUN pip install --no-cache-dir poetry && \
+    poetry export -o /requirements.txt && \
     mkdir -p /home/mqtt_io && \
     python -m venv /home/mqtt_io/venv && \
     /home/mqtt_io/venv/bin/pip install wheel
@@ -41,8 +39,8 @@ WORKDIR /home/mqtt_io
 
 COPY --from=requirements --chown=mqtt_io /home/mqtt_io/venv ./venv
 COPY --from=requirements /requirements.txt ./
-RUN venv/bin/python -m pip install --upgrade pip
-RUN venv/bin/pip install -r requirements.txt
+RUN venv/bin/python -m pip install --no-cache-dir --upgrade pip
+RUN venv/bin/pip install --no-cache-dir -r requirements.txt
 
 COPY --chown=mqtt_io mqtt_io mqtt_io
 


### PR DESCRIPTION
A follow up to the reverted #342, with extra improvements:

- Install rust from rustup. This seems to solve the issue reported in #342 
- Remove the `cryptography==3.3.2` hack, latest version builds fine with a recent rust.
- Install rust and other build dependencies only on arm/v7 (needed cause `cryptography` has no binary wheel).
- Use the `TARGETPLATFORM` predefined arg.

I tested that it builds on all platforms, but only ran it on arm64 (not on arm/v7).