### PR TITLE
Add tsl2561 light sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Hardware support is provided by specific GPIO, Sensor and Stream modules. It's e
   - DHT11/DHT22/AM2302 temperature and humidity sensors (`dht22`)
   - DS18S20/DS1822/DS18B20/DS1825/DS28EA00/MAX31850K temperature sensors (`ds18b`)
   - ENS160  digital multi-gas sensor with multiple IAQ data (TVOC, eCO2, AQI) (`ens160`)
+  - FREQUENCYCOUNTER Counts pulses from GPIOs and return the frequency in Hz (`frequencycounterr`)
+  - FLOWSENSOR generic flow rate sensor like YF-S201, YF-DN50 or others (`flowsensor`)
   - HCSR04 ultrasonic range sensor (connected to the Raspberry Pi on-board GPIO) (`hcsr04`)
   - INA219 DC current sensor (`ina219`)
   - LM75 temperature sensor (`lm75`)
@@ -45,9 +47,8 @@ Hardware support is provided by specific GPIO, Sensor and Stream modules. It's e
   - ADXl345 3-axis accelerometer up to ±16g  (`adxl345`)
   - PMS5003 particulate sensor (`pms5003`)
   - SHT40/SHT41/SHT45 temperature and humidity sensors (`sht4x`)
+  - TLSl2561 light level sensor (`tsl2561`)
   - YF-S201 flow rate sensor (`yfs201`)
-  - FREQUENCYCOUNTER Counts pulses from GPIOs and return the frequency in Hz (frequencycounter)
-  - FLOWSENSOR generic flow rate sensor like YF-S201 or YF-DN50 (`flowsensor`)
 
 
 ### Streams

--- a/mqtt_io/modules/sensor/tsl2561.py
+++ b/mqtt_io/modules/sensor/tsl2561.py
@@ -1,8 +1,6 @@
 """
 TSL2561 luminosity sensor
 """
-import threading
-
 from typing import cast
 
 from ...types import CerberusSchemaType, ConfigType, SensorValueType
@@ -10,19 +8,23 @@ from . import GenericSensor
 
 REQUIREMENTS = ("adafruit-circuitpython-tsl2561",)
 CONFIG_SCHEMA: CerberusSchemaType = {
-    "chip_addr": dict(type="integer", required=False, empty=False, default=0x48),
-    "integration_time": dict(
-        required=False,
-        empty=False,
-        allowed=[13.7, 101, 402],
-        default=101,
-    ),
-    "gain": dict(
-        required=False,
-        empty=False,
-        allowed=[1, 16],
-        default=1,
-    ),
+    "chip_addr": {
+        "type": 'integer',
+        "required": False,
+        "empty": False,
+        "default": '0x48'},
+    "integration_time": {
+        "required": False,
+        "empty": False,
+        "allowed": [13.7, 101, 402],
+        "default": 101,
+    },
+    "gain": {
+        "required": False,
+        "empty": False,
+        "allowed": [1, 16],
+        "default": 1,
+    },
 }
 
 
@@ -32,13 +34,13 @@ class Sensor(GenericSensor):
     """
 
     SENSOR_SCHEMA: CerberusSchemaType = {
-        "type": dict(
-            type="string",
-            required=False,
-            empty=False,
-            allowed=["broadband", "infrared", "lux"],
-            default="lux",
-        ),
+        "type": {
+            "type": 'string',
+            "required": False,
+            "empty": False,
+            "allowed": ['broadband', 'infrared', 'lux'],
+            "default": 'lux',
+        },
     }
 
     def setup_module(self) -> None:
@@ -83,23 +85,17 @@ class Sensor(GenericSensor):
         #print("tsl2561 Integration time = {}".format(self.tsl.integration_time))
 
     def get_value(self, sens_conf: ConfigType) -> SensorValueType:
-        import time
         """
         Get the values from the sensor
         """
-        self.tsl.enabled = True # Enable sensor
-        time.sleep(1)
-
         sens_type = sens_conf["type"]
-        data = dict(
-            broadband=self.tsl.broadband,
-            infrared=self.tsl.infrared,
-            lux=self.tsl.lux
-        )
+        data = {
+            "broadband": self.tsl.broadband,
+            "infrared": self.tsl.infrared,
+            "lux": self.tsl.lux
+        }
         if data[sens_type] is None: # Possible sensor underrange or overrange.
             data[sens_type] = -1
-
-        self.tsl.enabled = False # Disable for energy savings
 
         return cast(
             float,

--- a/mqtt_io/modules/sensor/tsl2561.py
+++ b/mqtt_io/modules/sensor/tsl2561.py
@@ -53,29 +53,28 @@ class Sensor(GenericSensor):
         self.i2c = busio.I2C(board.SCL, board.SDA)
 
         # Convert sensor address from hex to dec
-        self.address = 57
-        if self.config["chip_addr"] == 0x39:
-            self.address = 57
-        elif self.config["chip_addr"] == 0x49:
-            self.address = 73
-        elif self.config["chip_addr"] == 0x29:
-            self.address = 41
+        self.address = int(0x48)
+        if 'chip_addr' in self.config:
+            self.address = int(self.config['chip_addr'])
 
         self.tsl = adafruit_tsl2561.TSL2561(self.i2c, self.address)
 
         # Set gain 0=1x, 1=16x
-        if self.config["gain"] == 1:
-            self.tsl.gain = 0
-        elif self.config["gain"] == 16:
-            self.tsl.gain = 1
+        gains = {
+            "1": 0,
+            "16": 1,
+        }
+        if 'gain' in self.config:
+            self.tsl.gain = gains[str(self.config["gain"])]
 
         # Set integration time (0=13.7ms, 1=101ms, 2=402ms, or 3=manual)
-        if self.config["integration_time"] == 13.7:
-            self.tsl.integration_time = 0
-        elif self.config["integration_time"] == 101:
-            self.tsl.integration_time = 1
-        elif self.config["integration_time"] == 402:
-            self.tsl.integration_time = 2
+        ints = {
+            "13.7": 0,
+            "101": 1,
+            "402": 2,
+        }
+        if 'integration_time' in self.config:
+            self.tsl.integration_time = ints[str(self.config["integration_time"])]
 
         self.tsl.enabled = True
 
@@ -87,7 +86,6 @@ class Sensor(GenericSensor):
         # pylint: disable=import-outside-toplevel,attribute-defined-outside-init
         # pylint: disable=import-error,no-member
         import time
-
         self.tsl.enabled = True
         time.sleep(1)
 

--- a/mqtt_io/modules/sensor/tsl2561.py
+++ b/mqtt_io/modules/sensor/tsl2561.py
@@ -6,7 +6,7 @@ from typing import cast
 from ...types import CerberusSchemaType, ConfigType, SensorValueType
 from . import GenericSensor
 
-REQUIREMENTS = ("adafruit-circuitpython-tsl2561",) # type: ignore
+REQUIREMENTS = ("adafruit-circuitpython-tsl2561",)
 CONFIG_SCHEMA: CerberusSchemaType = {
     "chip_addr": {
         "type": 'integer',
@@ -48,7 +48,7 @@ class Sensor(GenericSensor):
         # pylint: disable=import-error,no-member
         import board  # type: ignore
         import busio  # type: ignore
-        import adafruit_tsl2561
+        import adafruit_tsl2561 # type: ignore
         # Create the I2C bus
         self.i2c = busio.I2C(board.SCL, board.SDA)
 
@@ -62,7 +62,6 @@ class Sensor(GenericSensor):
             self.address = 41
 
         self.tsl = adafruit_tsl2561.TSL2561(self.i2c, self.address)
-
 
         # Set gain 0=1x, 1=16x
         if self.config["gain"] == 1:
@@ -85,15 +84,22 @@ class Sensor(GenericSensor):
         #print("tsl2561 Integration time = {}".format(self.tsl.integration_time))
 
     def get_value(self, sens_conf: ConfigType) -> SensorValueType:
-        """
-        Get the values from the sensor
-        """
+        # pylint: disable=import-outside-toplevel,attribute-defined-outside-init
+        # pylint: disable=import-error,no-member
+        import time
+
+        self.tsl.enabled = True
+        time.sleep(1)
+
         sens_type = sens_conf["type"]
         data = {
             "broadband": self.tsl.broadband,
             "infrared": self.tsl.infrared,
             "lux": self.tsl.lux
         }
+
+        self.tsl.enabled = False
+
         if data[sens_type] is None: # Possible sensor underrange or overrange.
             data[sens_type] = -1
 

--- a/mqtt_io/modules/sensor/tsl2561.py
+++ b/mqtt_io/modules/sensor/tsl2561.py
@@ -1,0 +1,107 @@
+"""
+TSL2561 luminosity sensor
+"""
+import threading
+
+from typing import cast
+
+from ...types import CerberusSchemaType, ConfigType, SensorValueType
+from . import GenericSensor
+
+REQUIREMENTS = ("adafruit-circuitpython-tsl2561",)
+CONFIG_SCHEMA: CerberusSchemaType = {
+    "chip_addr": dict(type="integer", required=False, empty=False, default=0x48),
+    "integration_time": dict(
+        required=False,
+        empty=False,
+        allowed=[13.7, 101, 402],
+        default=101,
+    ),
+    "gain": dict(
+        required=False,
+        empty=False,
+        allowed=[1, 16],
+        default=1,
+    ),
+}
+
+
+class Sensor(GenericSensor):
+    """
+    Implementation of Sensor class for the Adafruit_ADS1x15.
+    """
+
+    SENSOR_SCHEMA: CerberusSchemaType = {
+        "type": dict(
+            type="string",
+            required=False,
+            empty=False,
+            allowed=["broadband", "infrared", "lux"],
+            default="lux",
+        ),
+    }
+
+    def setup_module(self) -> None:
+        # pylint: disable=import-outside-toplevel,attribute-defined-outside-init
+        # pylint: disable=import-error,no-member
+        import board  # type: ignore
+        import busio  # type: ignore
+        import adafruit_tsl2561
+        # Create the I2C bus
+        self.i2c = busio.I2C(board.SCL, board.SDA)
+
+        # Convert sensor address from hex to dec
+        self.address = 57
+        if self.config["chip_addr"] == 0x39:
+            self.address = 57
+        elif self.config["chip_addr"] == 0x49:
+            self.address = 73
+        elif self.config["chip_addr"] == 0x29:
+            self.address = 41
+
+        self.tsl = adafruit_tsl2561.TSL2561(self.i2c, self.address)
+
+
+        # Set gain 0=1x, 1=16x
+        if self.config["gain"] == 1:
+            self.tsl.gain = 0
+        elif self.config["gain"] == 16:
+            self.tsl.gain = 1
+
+        # Set integration time (0=13.7ms, 1=101ms, 2=402ms, or 3=manual)
+        if self.config["integration_time"] == 13.7:
+            self.tsl.integration_time = 0
+        elif self.config["integration_time"] == 101:
+            self.tsl.integration_time = 1
+        elif self.config["integration_time"] == 402:
+            self.tsl.integration_time = 2
+
+        self.tsl.enabled = True
+
+        #print("tsl2561 Enabled = {}".format(self.tsl.enabled))
+        #print("tsl2561 Gain = {}".format(self.tsl.gain))
+        #print("tsl2561 Integration time = {}".format(self.tsl.integration_time))
+
+    def get_value(self, sens_conf: ConfigType) -> SensorValueType:
+        import time
+        """
+        Get the values from the sensor
+        """
+        self.tsl.enabled = True # Enable sensor
+        time.sleep(1)
+
+        sens_type = sens_conf["type"]
+        data = dict(
+            broadband=self.tsl.broadband,
+            infrared=self.tsl.infrared,
+            lux=self.tsl.lux
+        )
+        if data[sens_type] is None: # Possible sensor underrange or overrange.
+            data[sens_type] = -1
+
+        self.tsl.enabled = False # Disable for energy savings
+
+        return cast(
+            float,
+            data[sens_type],
+        )

--- a/mqtt_io/modules/sensor/tsl2561.py
+++ b/mqtt_io/modules/sensor/tsl2561.py
@@ -6,7 +6,7 @@ from typing import cast
 from ...types import CerberusSchemaType, ConfigType, SensorValueType
 from . import GenericSensor
 
-REQUIREMENTS = ("adafruit-circuitpython-tsl2561",)
+REQUIREMENTS = ("adafruit-circuitpython-tsl2561",) # type: ignore
 CONFIG_SCHEMA: CerberusSchemaType = {
     "chip_addr": {
         "type": 'integer',


### PR DESCRIPTION
Add TSL2561 Light sensor, based on library from Adafruit. Config example:

```
sensor_modules:
- chip_addr: 0x39
  module: tsl2561
  name: tsl2561_1
  gain: 1
  integration_time: 13.7
sensor_inputs:
- digits: 4
  interval: 30
  module: tsl2561_1
  name: illuminance_tsl2561
  type: lux
  retain: true
