### PR TITLE
Add support for DFR0300 EC sensor 

### DIFF
--- a/mqtt_io/modules/sensor/__init__.py
+++ b/mqtt_io/modules/sensor/__init__.py
@@ -38,7 +38,7 @@ class GenericSensor(abc.ABC):
         in `self.config`.
         """
 
-    def setup_sensor(self, sens_conf: ConfigType, event_bus: EventBus = None) -> None:
+    def setup_sensor(self, sens_conf: ConfigType, event_bus: EventBus) -> None:
         """
         Called on initialisation of each reading type of the Sensor module during the
         startup phase.

--- a/mqtt_io/modules/sensor/__init__.py
+++ b/mqtt_io/modules/sensor/__init__.py
@@ -7,6 +7,8 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
+from mqtt_io.events import EventBus
+
 from ...types import ConfigType, SensorValueType
 
 
@@ -36,13 +38,16 @@ class GenericSensor(abc.ABC):
         in `self.config`.
         """
 
-    def setup_sensor(self, sens_conf: ConfigType) -> None:
+    def setup_sensor(self, sens_conf: ConfigType, event_bus: EventBus = None) -> None:
         """
         Called on initialisation of each reading type of the Sensor module during the
         startup phase.
 
         The `sens_conf` passed in here is the sensor's entry in the `sensor_inputs`
         section of the config file.
+
+        The `event_bus` is the system event bus so that it is possible to track and respond
+        to other events, such as other sensor readings.
         """
 
     def cleanup(self) -> None:

--- a/mqtt_io/modules/sensor/bme680.py
+++ b/mqtt_io/modules/sensor/bme680.py
@@ -4,13 +4,15 @@ BME680 temperature, humidity and pressure sensor
 
 from typing import cast
 
+from mqtt_io.events import EventBus
+
 from ...types import CerberusSchemaType, ConfigType, SensorValueType
 from . import GenericSensor
 
 REQUIREMENTS = ("smbus2", "bme680")
 CONFIG_SCHEMA = {
-    "i2c_bus_num": {"type": 'integer', "required": False, "empty": False},
-    "chip_addr": {"type": 'integer', "required": True, "empty": False},
+    "i2c_bus_num": {"type": "integer", "required": False, "empty": False},
+    "chip_addr": {"type": "integer", "required": True, "empty": False},
 }
 
 
@@ -21,15 +23,15 @@ class Sensor(GenericSensor):
 
     SENSOR_SCHEMA: CerberusSchemaType = {
         "type": {
-            "type": 'string',
+            "type": "string",
             "required": False,
-            "default": 'temperature',
-            "allowed": ['temperature', 'humidity', 'pressure'],
+            "default": "temperature",
+            "allowed": ["temperature", "humidity", "pressure"],
         },
         "oversampling": {
-            "type": 'string',
+            "type": "string",
             "required": False,
-            "allowed": ['none', '1x', '2x', '4x', '8x', '16x'],
+            "allowed": ["none", "1x", "2x", "4x", "8x", "16x"],
         },
     }
 
@@ -53,7 +55,7 @@ class Sensor(GenericSensor):
             "16x": bme680.OS_16X,
         }
 
-    def setup_sensor(self, sens_conf: ConfigType) -> None:
+    def setup_sensor(self, sens_conf: ConfigType, event_bus: EventBus) -> None:
         sens_type: str = sens_conf["type"]
         if "oversampling" in sens_conf:
             set_oversampling = getattr(self.sensor, f"set_{sens_type}_oversample")

--- a/mqtt_io/modules/sensor/dfr0300.py
+++ b/mqtt_io/modules/sensor/dfr0300.py
@@ -1,0 +1,229 @@
+"""
+DFRobot Gravity DFR0300 Electrical Conductivity Sensor
+"""
+
+import abc
+import json
+import logging
+import os
+import time
+
+from typing import cast
+
+from mqtt_io.events import EventBus, SensorReadEvent
+from mqtt_io.exceptions import RuntimeConfigError
+
+from ...types import CerberusSchemaType, ConfigType, PinType, SensorValueType
+from . import GenericSensor
+
+_LOG = logging.getLogger(__name__)
+
+INITIAL_KVALUE = 1.0
+
+CONFIG_SCHEMA: CerberusSchemaType = {
+    "i2c_bus_num": {"type": "integer", "required": False, "empty": False, "default": 1},
+    "chip_addr": {
+        "type": "integer",
+        "required": False,
+        "empty": False,
+        "default": 0x10,
+    },
+}
+
+ANALOG_PINS = [0, 1, 2, 3]
+BOARD_SETUP_TRIES = 3
+BOARD_SETUP_TIMEOUT = 2
+CALIBRATION_FILE = "ec_config.json"
+CALIBRATION_FILE_ENCODING = "ascii"
+DEFAULT_TEMPERATURE = 25.0
+TEMPSENSOR_ID = "tempsensor"
+
+
+def board_status_str(board) -> str:
+    """Return board status as string."""
+    return {
+        board.STA_OK: "STA_OK",
+        board.STA_ERR: "STA_ERR",
+        board.STA_ERR_DEVICE_NOT_DETECTED: "STA_ERR_DEVICE_NOT_DETECTED",
+        board.STA_ERR_PARAMETER: "STA_ERR_PARAMETER",
+        board.STA_ERR_SOFT_VERSION: "STA_ERR_SOFT_VERSION",
+    }.get(board.last_operate_status, "unknown error")
+
+
+def raw_ec(voltage: float) -> float:
+    """Convert voltage to raw EC"""
+    return 1000 * voltage / 820.0 / 200.0
+
+
+class Calibrator(abc.ABC):
+    """Class to handle calibration"""
+
+    def __init__(self) -> None:
+        self.kvalue_low, self.kvalue_mid, self.kvalue_high = self.read_calibration()
+
+    def calibrate(self, voltage, temperature) -> None:
+        """Set the calibration values and write out to file."""
+
+        def calc_kvalue(ec_solution, voltage, temperature):
+            comp_ec_solution = ec_solution * (1.0 + 0.0185 * (temperature - 25.0))
+            return round(820.0 * 200.0 * comp_ec_solution / 1000.0 / voltage, 2)
+
+        my_raw_ec = raw_ec(voltage)
+        if 0.9 < my_raw_ec < 1.9:
+            self.kvalue_low = calc_kvalue(1.413, voltage, temperature)
+            _LOG.info(">>>Buffer Solution:1.413us/cm kvalue_low: %f", self.kvalue_low)
+        elif 1.9 <= my_raw_ec < 4:
+            self.kvalue_mid = calc_kvalue(2.8, voltage, temperature)
+            _LOG.info(">>>EC:2.8ms/cm kvalue_mid: %f", self.kvalue_mid)
+        elif 9 < my_raw_ec < 16.8:
+            self.kvalue_high = calc_kvalue(12.88, voltage, temperature)
+            _LOG.info(">>>Buffer Solution:12.88ms/cm kvalue_high:%f ", self.kvalue_high)
+        else:
+            raise ValueError(">>>Buffer Solution Error Try Again<<<")
+
+        # Should think about looping to stabalise the reading before writing
+        self.write_calibration()
+
+    def read_calibration(self):
+        """Read calibrated values from json file.
+        {
+          "kvalue_low": 1.0,
+          "kvalue_mid": 1.04,
+          "kvalue_high": 1.0
+        }
+
+        """
+        # Default values
+        kvalue_low = 1.0
+        kvalue_mid = 1.04
+        kvalue_high = 1.0
+        if os.path.exists(CALIBRATION_FILE):
+            with open("ec_config.json", "r", encoding=CALIBRATION_FILE_ENCODING) as f:
+                data = json.load(f)
+                kvalue_low = float(data["kvalue_low"])
+                kvalue_mid = float(data["kvalue_mid"])
+                kvalue_high = float(data["kvalue_high"])
+        return (kvalue_low, kvalue_mid, kvalue_high)
+
+    def write_calibration(self):
+        """Write calibrated values to json file."""
+        try:
+            with open(CALIBRATION_FILE, "w", encoding=CALIBRATION_FILE_ENCODING) as f:
+                data = {
+                    "kvalue_low": self.kvalue_low,
+                    "kvalue_mid": self.kvalue_mid,
+                    "kvalue_high": self.kvalue_high,
+                }
+                json.dump(data, f, indent=2, encoding="ascii")
+        except IOError as exc:
+            _LOG.warning("Failed to write calibration data: %s", exc)
+
+
+class Sensor(GenericSensor):
+    """
+    Implementation of Sensor class for the DFR0300 Electrical Conductivity Sensor
+
+    """
+
+    SENSOR_SCHEMA: CerberusSchemaType = {
+        "pin": {
+            "type": "integer",
+            "required": True,
+            "empty": False,
+            "allowed": ANALOG_PINS,
+        },
+        TEMPSENSOR_ID: {
+            "type": "string",
+            "required": False,
+            "empty": False,
+        },
+    }
+
+    def setup_sensor(self, sens_conf: ConfigType, event_bus: EventBus = None) -> None:
+        """
+        Setup the sensor module
+        """
+        # pylint: disable=attribute-defined-outside-init
+        self.temperature = DEFAULT_TEMPERATURE
+
+        if TEMPSENSOR_ID not in sens_conf:
+            print("NOT setting up temperature sensor")
+            return
+
+        print("Setting up temperature sensor")
+
+        def on_sensor_read(data):
+            """Callback for sensor read event"""
+            print("Sensor read event cb", dir(data))
+            if data.sensor_name == sens_conf[TEMPSENSOR_ID] and data.value is not None:
+                self.temperature = data.value
+
+        self.event_bus = event_bus
+        self.event_bus.subscribe(SensorReadEvent, on_sensor_read)
+
+    def setup_module(self) -> None:
+        # pylint: disable=import-outside-toplevel,import-error
+        from .drivers.DFRobot_RaspberryPi_Expansion_Board import DFRobotExpansionBoardIIC  # type: ignore
+
+        self.board = DFRobotExpansionBoardIIC(
+            self.config["i2c_bus_num"], self.config["chip_addr"]
+        )  # type: ignore
+        count = 0
+        while self.board.begin() != self.board.STA_OK:
+            count += 1
+            if count > BOARD_SETUP_TRIES:
+                raise RuntimeError(
+                    "board begin failed: %s" % board_status_str(self.board)
+                )
+            time.sleep(BOARD_SETUP_TIMEOUT)
+
+        self.board.set_adc_enable()
+        self.pin2channel = {
+            0: self.board.A0,
+            1: self.board.A1,
+            2: self.board.A2,
+            3: self.board.A3,
+        }
+
+        self.kvalue = INITIAL_KVALUE
+        calibrator = Calibrator()
+        self.kvalue_low = calibrator.kvalue_low
+        self.kvalue_mid = calibrator.kvalue_mid
+        self.kvalue_high = calibrator.kvalue_high
+
+    def ec_from_voltage(self, voltage, temperature):
+        """Convert voltage to EC with temperature compensation"""
+        # pylint: disable=attribute-defined-outside-init
+        my_raw_ec = raw_ec(voltage)
+        value_temp = my_raw_ec * self.kvalue
+        if value_temp > 5.0:
+            self.kvalue = self.kvalue_high
+        elif value_temp >= 2.0:
+            self.kvalue = self.kvalue_mid
+        elif value_temp < 2.0:
+            self.kvalue = self.kvalue_low
+        value = my_raw_ec * self.kvalue
+        value = value / (1.0 + 0.0185 * (temperature - 25.0))
+        return value
+
+    def get_value(self, sens_conf: ConfigType) -> SensorValueType:
+        """
+        Get the EC from the sensor
+        """
+        pin: PinType = sens_conf["pin"]
+        try:
+            channel = self.pin2channel[pin]
+        except KeyError as exc:
+            raise RuntimeConfigError(
+                "pin '%s' was not configured to return a valid value" % pin
+            ) from exc
+
+        voltage = self.board.get_adc_value(channel)
+        ec = self.ec_from_voltage(voltage, self.temperature)
+
+        _LOG.info("Temperature:%.1f ^C EC:%.2f ms/cm", self.temperature, ec)
+
+        return cast(
+            float,
+            ec,
+        )

--- a/mqtt_io/modules/sensor/dfr0300.py
+++ b/mqtt_io/modules/sensor/dfr0300.py
@@ -6,7 +6,6 @@ import abc
 import json
 import logging
 import os
-import time
 
 from typing import cast
 
@@ -171,8 +170,8 @@ class Sensor(GenericSensor):
 
         def on_sensor_read(data):
             """Callback for sensor read event"""
-            _LOG.info("Sensor read event cb %s", dir(data))
             if data.sensor_name == sens_conf[TEMPSENSOR_ID] and data.value is not None:
+                _LOG.info("Set self.temperature %s", dir(data))
                 self.temperature = data.value
 
         self.event_bus = event_bus

--- a/mqtt_io/modules/sensor/dfr0300.py
+++ b/mqtt_io/modules/sensor/dfr0300.py
@@ -180,10 +180,15 @@ class Sensor(GenericSensor):
             _LOG.info("dfr0300: No temperature sensor configured")
             return
 
-        def on_sensor_read(data: SensorReadEvent) -> None:
-            """Callback for sensor read event"""
-            if data.sensor_name == sens_conf[TEMPSENSOR_ID] and data.value is not None:
-                self.temperature = data.value
+        async def on_sensor_read(event: SensorReadEvent) -> None:
+            """Callback for sensor read event
+            Sets self.temperature from the temperature sensor
+            """
+            if (
+                event.sensor_name == sens_conf[TEMPSENSOR_ID]
+                and event.value is not None
+            ):
+                self.temperature = event.value
 
         event_bus.subscribe(SensorReadEvent, on_sensor_read)
 

--- a/mqtt_io/modules/sensor/dfr0300.py
+++ b/mqtt_io/modules/sensor/dfr0300.py
@@ -139,7 +139,7 @@ class Sensor(GenericSensor):
         },
     }
 
-    def setup_sensor(self, sens_conf: ConfigType, event_bus: EventBus = None) -> None:
+    def setup_sensor(self, sens_conf: ConfigType, event_bus: EventBus) -> None:
         """
         Setup the sensor module
         """

--- a/mqtt_io/modules/sensor/dfr0300.py
+++ b/mqtt_io/modules/sensor/dfr0300.py
@@ -18,7 +18,6 @@ from . import GenericSensor
 
 _LOG = logging.getLogger(__name__)
 
-INITIAL_KVALUE = 1.0
 
 CONFIG_SCHEMA: CerberusSchemaType = {
     "i2c_bus_num": {"type": "integer", "required": False, "empty": False, "default": 1},
@@ -31,26 +30,14 @@ CONFIG_SCHEMA: CerberusSchemaType = {
 }
 
 ANALOG_PINS = [0, 1, 2, 3]
-BOARD_SETUP_TRIES = 3
-BOARD_SETUP_TIMEOUT = 2
 CALIBRATION_FILE = "ec_config.json"
 CALIBRATION_FILE_ENCODING = "ascii"
 DEFAULT_TEMPERATURE = 25.0
+INITIAL_KVALUE = 1.0
 TEMPSENSOR_ID = "tempsensor"
 
 
-def board_status_str(board) -> str:
-    """Return board status as string."""
-    return {
-        board.STA_OK: "STA_OK",
-        board.STA_ERR: "STA_ERR",
-        board.STA_ERR_DEVICE_NOT_DETECTED: "STA_ERR_DEVICE_NOT_DETECTED",
-        board.STA_ERR_PARAMETER: "STA_ERR_PARAMETER",
-        board.STA_ERR_SOFT_VERSION: "STA_ERR_SOFT_VERSION",
-    }.get(board.last_operate_status, "unknown error")
-
-
-def raw_ec(voltage: float) -> float:
+def calc_raw_ec(voltage: float) -> float:
     """Convert voltage to raw EC"""
     return 1000 * voltage / 820.0 / 200.0
 
@@ -59,7 +46,11 @@ class Calibrator(abc.ABC):
     """Class to handle calibration"""
 
     def __init__(self) -> None:
-        self.kvalue_low, self.kvalue_mid, self.kvalue_high = self.read_calibration()
+        self.kvalue_low = INITIAL_KVALUE
+        self.kvalue_mid = INITIAL_KVALUE
+        self.kvalue_high = INITIAL_KVALUE
+        if os.path.exists(CALIBRATION_FILE):
+            self.kvalue_low, self.kvalue_mid, self.kvalue_high = self.read_calibration()
 
     def calibrate(self, voltage, temperature) -> None:
         """Set the calibration values and write out to file."""
@@ -68,14 +59,14 @@ class Calibrator(abc.ABC):
             comp_ec_solution = ec_solution * (1.0 + 0.0185 * (temperature - 25.0))
             return round(820.0 * 200.0 * comp_ec_solution / 1000.0 / voltage, 2)
 
-        my_raw_ec = raw_ec(voltage)
-        if 0.9 < my_raw_ec < 1.9:
+        raw_ec = calc_raw_ec(voltage)
+        if 0.9 < raw_ec < 1.9:
             self.kvalue_low = calc_kvalue(1.413, voltage, temperature)
             _LOG.info(">>>Buffer Solution:1.413us/cm kvalue_low: %f", self.kvalue_low)
-        elif 1.9 <= my_raw_ec < 4:
+        elif 1.9 <= raw_ec < 4:
             self.kvalue_mid = calc_kvalue(2.8, voltage, temperature)
             _LOG.info(">>>EC:2.8ms/cm kvalue_mid: %f", self.kvalue_mid)
-        elif 9 < my_raw_ec < 16.8:
+        elif 9 < raw_ec < 16.8:
             self.kvalue_high = calc_kvalue(12.88, voltage, temperature)
             _LOG.info(">>>Buffer Solution:12.88ms/cm kvalue_high:%f ", self.kvalue_high)
         else:
@@ -88,22 +79,19 @@ class Calibrator(abc.ABC):
         """Read calibrated values from json file.
         {
           "kvalue_low": 1.0,
-          "kvalue_mid": 1.04,
+          "kvalue_mid": 1.0,
           "kvalue_high": 1.0
         }
 
         """
-        # Default values
-        kvalue_low = 1.0
-        kvalue_mid = 1.04
-        kvalue_high = 1.0
         if os.path.exists(CALIBRATION_FILE):
-            with open("ec_config.json", "r", encoding=CALIBRATION_FILE_ENCODING) as f:
+            with open(CALIBRATION_FILE, "r", encoding=CALIBRATION_FILE_ENCODING) as f:
                 data = json.load(f)
                 kvalue_low = float(data["kvalue_low"])
                 kvalue_mid = float(data["kvalue_mid"])
                 kvalue_high = float(data["kvalue_high"])
-        return (kvalue_low, kvalue_mid, kvalue_high)
+            return (kvalue_low, kvalue_mid, kvalue_high)
+        raise FileNotFoundError(f"Calibration file ${CALIBRATION_FILE} not found")
 
     def write_calibration(self):
         """Write calibrated values to json file."""
@@ -139,26 +127,6 @@ class Sensor(GenericSensor):
         },
     }
 
-    def setup_sensor(self, sens_conf: ConfigType, event_bus: EventBus) -> None:
-        """
-        Setup the sensor module
-        """
-        # pylint: disable=attribute-defined-outside-init
-        self.temperature = DEFAULT_TEMPERATURE
-
-        if TEMPSENSOR_ID not in sens_conf:
-            _LOG.info("dfr0300: No temperature sensor configured")
-            return
-
-        def on_sensor_read(data):
-            """Callback for sensor read event"""
-            _LOG.info("Sensor read event cb %s", dir(data))
-            if data.sensor_name == sens_conf[TEMPSENSOR_ID] and data.value is not None:
-                self.temperature = data.value
-
-        self.event_bus = event_bus
-        self.event_bus.subscribe(SensorReadEvent, on_sensor_read)
-
     def setup_module(self) -> None:
         # pylint: disable=import-outside-toplevel,import-error
         from .drivers.DFRobot_RaspberryPi_Expansion_Board import DFRobotExpansionBoardIIC  # type: ignore
@@ -166,14 +134,7 @@ class Sensor(GenericSensor):
         self.board = DFRobotExpansionBoardIIC(
             self.config["i2c_bus_num"], self.config["chip_addr"]
         )  # type: ignore
-        count = 0
-        while self.board.begin() != self.board.STA_OK:
-            count += 1
-            if count > BOARD_SETUP_TRIES:
-                raise RuntimeError(
-                    "board begin failed: %s" % board_status_str(self.board)
-                )
-            time.sleep(BOARD_SETUP_TIMEOUT)
+        self.board.setup()
 
         self.board.set_adc_enable()
         self.pin2channel = {
@@ -189,38 +150,55 @@ class Sensor(GenericSensor):
         self.kvalue_mid = calibrator.kvalue_mid
         self.kvalue_high = calibrator.kvalue_high
 
+    def setup_sensor(self, sens_conf: ConfigType, event_bus: EventBus) -> None:
+        """
+        Setup the sensor module
+        """
+        # pylint: disable=attribute-defined-outside-init
+        self.temperature = DEFAULT_TEMPERATURE
+
+        pin: PinType = sens_conf["pin"]
+        try:
+            self.channel = self.pin2channel[pin]
+        except KeyError as exc:
+            raise RuntimeConfigError(
+                "pin '%s' was not configured to return a valid value" % pin
+            ) from exc
+
+        if TEMPSENSOR_ID not in sens_conf:
+            _LOG.info("dfr0300: No temperature sensor configured")
+            return
+
+        def on_sensor_read(data):
+            """Callback for sensor read event"""
+            _LOG.info("Sensor read event cb %s", dir(data))
+            if data.sensor_name == sens_conf[TEMPSENSOR_ID] and data.value is not None:
+                self.temperature = data.value
+
+        self.event_bus = event_bus
+        self.event_bus.subscribe(SensorReadEvent, on_sensor_read)
+
     def ec_from_voltage(self, voltage, temperature):
         """Convert voltage to EC with temperature compensation"""
         # pylint: disable=attribute-defined-outside-init
-        my_raw_ec = raw_ec(voltage)
-        value_temp = my_raw_ec * self.kvalue
+        raw_ec = calc_raw_ec(voltage)
+        value_temp = raw_ec * self.kvalue
         if value_temp > 5.0:
             self.kvalue = self.kvalue_high
         elif value_temp >= 2.0:
             self.kvalue = self.kvalue_mid
         elif value_temp < 2.0:
             self.kvalue = self.kvalue_low
-        value = my_raw_ec * self.kvalue
-        value = value / (1.0 + 0.0185 * (temperature - 25.0))
-        return value
+        value = raw_ec * self.kvalue
+        return value / (1.0 + 0.0185 * (temperature - 25.0))
 
-    def get_value(self, sens_conf: ConfigType) -> SensorValueType:
+    def get_value(self, _sens_conf: ConfigType) -> SensorValueType:
         """
         Get the EC from the sensor
         """
-        pin: PinType = sens_conf["pin"]
-        try:
-            channel = self.pin2channel[pin]
-        except KeyError as exc:
-            raise RuntimeConfigError(
-                "pin '%s' was not configured to return a valid value" % pin
-            ) from exc
-
-        voltage = self.board.get_adc_value(channel)
+        voltage = self.board.get_adc_value(self.channel)
         ec = self.ec_from_voltage(voltage, self.temperature)
-
         _LOG.info("Temperature:%.1f ^C EC:%.2f ms/cm", self.temperature, ec)
-
         return cast(
             float,
             ec,

--- a/mqtt_io/modules/sensor/dfr0300.py
+++ b/mqtt_io/modules/sensor/dfr0300.py
@@ -188,10 +188,10 @@ class Sensor(GenericSensor):
         }
 
         self.kvalue = INITIAL_KVALUE
-        calibrator = Calibrator()
-        self.kvalue_low = calibrator.kvalue_low
-        self.kvalue_mid = calibrator.kvalue_mid
-        self.kvalue_high = calibrator.kvalue_high
+        self.calibrator = Calibrator()
+        self.kvalue_low = self.calibrator.kvalue_low
+        self.kvalue_mid = self.calibrator.kvalue_mid
+        self.kvalue_high = self.calibrator.kvalue_high
 
     def setup_sensor(self, sens_conf: ConfigType, event_bus: EventBus) -> None:
         """

--- a/mqtt_io/modules/sensor/dfr0300.py
+++ b/mqtt_io/modules/sensor/dfr0300.py
@@ -1,5 +1,29 @@
 """
 DFRobot Gravity DFR0300 Electrical Conductivity Sensor
+
+Example config (including optional temperature sensor):
+
+sensor_modules:
+  - name: aht20_temp
+    module: aht20
+  - name: dfr0300
+    module: dfr0300
+
+sensor_inputs:
+  - name: temperature
+    module: aht20_temp 
+    type: temperature
+    interval: 10
+    digits: 4
+
+  - name: ec
+    module: dfr0300
+    pin: 0
+    tempsensor: temperature
+    interval: 10
+    digits: 4
+
+
 """
 
 import abc
@@ -17,7 +41,7 @@ from . import GenericSensor
 
 _LOG = logging.getLogger(__name__)
 
-
+REQUIREMENTS = ("smbus",)
 CONFIG_SCHEMA: CerberusSchemaType = {
     "i2c_bus_num": {"type": "integer", "required": False, "empty": False, "default": 1},
     "chip_addr": {

--- a/mqtt_io/modules/sensor/dfr0300.py
+++ b/mqtt_io/modules/sensor/dfr0300.py
@@ -75,7 +75,8 @@ class Calibrator(abc.ABC):
         self.kvalue_low: float = INITIAL_KVALUE
         self.kvalue_mid: float = INITIAL_KVALUE
         self.kvalue_high: float = INITIAL_KVALUE
-        if os.path.exists(CALIBRATION_FILE):
+        self.calibration_file = CALIBRATION_FILE
+        if os.path.exists(self.calibration_file):
             self.kvalue_low, self.kvalue_mid, self.kvalue_high = self.read_calibration()
 
     def calibrate(self, voltage: float, temperature: float) -> None:
@@ -103,8 +104,7 @@ class Calibrator(abc.ABC):
         # Should think about looping to stabalise the reading before writing
         self.write_calibration()
 
-    @staticmethod
-    def read_calibration() -> Tuple[float, float, float]:
+    def read_calibration(self) -> Tuple[float, float, float]:
         """Read calibrated values from json file.
         {
           "kvalue_low": 1.0,
@@ -113,22 +113,22 @@ class Calibrator(abc.ABC):
         }
 
         """
-        if os.path.exists(CALIBRATION_FILE):
+        if os.path.exists(self.calibration_file):
             with open(
-                CALIBRATION_FILE, "r", encoding=CALIBRATION_FILE_ENCODING
+                self.calibration_file, "r", encoding=CALIBRATION_FILE_ENCODING
             ) as file_handle:
                 data = json.load(file_handle)
                 kvalue_low = float(data["kvalue_low"])
                 kvalue_mid = float(data["kvalue_mid"])
                 kvalue_high = float(data["kvalue_high"])
             return (kvalue_low, kvalue_mid, kvalue_high)
-        raise FileNotFoundError(f"Calibration file ${CALIBRATION_FILE} not found")
+        raise FileNotFoundError(f"Calibration file ${self.calibration_file} not found")
 
     def write_calibration(self) -> None:
         """Write calibrated values to json file."""
         try:
             with open(
-                CALIBRATION_FILE, "w", encoding=CALIBRATION_FILE_ENCODING
+                self.calibration_file, "w", encoding=CALIBRATION_FILE_ENCODING
             ) as file_handle:
                 data = {
                     "kvalue_low": self.kvalue_low,

--- a/mqtt_io/modules/sensor/dfr0300.py
+++ b/mqtt_io/modules/sensor/dfr0300.py
@@ -138,7 +138,7 @@ class Sensor(GenericSensor):
 
     def setup_module(self) -> None:
         # pylint: disable=import-outside-toplevel,import-error
-        from .drivers.DFRobot_RaspberryPi_Expansion_Board import (
+        from .drivers.dfr0566_driver import (
             DFRobotExpansionBoardIIC,
         )  # type: ignore
 

--- a/mqtt_io/modules/sensor/dfr0300.py
+++ b/mqtt_io/modules/sensor/dfr0300.py
@@ -171,7 +171,6 @@ class Sensor(GenericSensor):
         def on_sensor_read(data):
             """Callback for sensor read event"""
             if data.sensor_name == sens_conf[TEMPSENSOR_ID] and data.value is not None:
-                _LOG.info("Set self.temperature %s", dir(data))
                 self.temperature = data.value
 
         self.event_bus = event_bus
@@ -197,7 +196,7 @@ class Sensor(GenericSensor):
         """
         voltage = self.board.get_adc_value(self.channel)
         ec = self.ec_from_voltage(voltage, self.temperature)
-        _LOG.info("Temperature:%.1f ^C EC:%.2f ms/cm", self.temperature, ec)
+        #_LOG.info("Temperature:%.2f ^C EC:%.2f ms/cm", self.temperature, ec)
         return cast(
             float,
             ec,

--- a/mqtt_io/modules/sensor/dfr0300.py
+++ b/mqtt_io/modules/sensor/dfr0300.py
@@ -147,14 +147,12 @@ class Sensor(GenericSensor):
         self.temperature = DEFAULT_TEMPERATURE
 
         if TEMPSENSOR_ID not in sens_conf:
-            print("NOT setting up temperature sensor")
+            _LOG.info("dfr0300: No temperature sensor configured")
             return
-
-        print("Setting up temperature sensor")
 
         def on_sensor_read(data):
             """Callback for sensor read event"""
-            print("Sensor read event cb", dir(data))
+            _LOG.info("Sensor read event cb %s", dir(data))
             if data.sensor_name == sens_conf[TEMPSENSOR_ID] and data.value is not None:
                 self.temperature = data.value
 

--- a/mqtt_io/modules/sensor/drivers/DFRobot_RaspberryPi_Expansion_Board.py
+++ b/mqtt_io/modules/sensor/drivers/DFRobot_RaspberryPi_Expansion_Board.py
@@ -1,0 +1,328 @@
+# -*- coding:utf-8 -*-
+
+"""
+  Adapted from the below by @linucks
+
+  @file DFRobot_RaspberryPi_Expansion_Board.py
+  @brief This RaspberryPi expansion board can communicate with RaspberryPi via I2C. It has 10 GPIOs, 1 SPI, 4 I2Cs and 1 uart.
+  @copyright   Copyright (c) 2010 DFRobot Co.Ltd (http://www.dfrobot.com)
+  @license     The MIT License (MIT)
+  @author      Frank(jiehan.guo@dfrobot.com)
+  @version     V1.0
+  @date        2019-3-28
+  @url https://github.com/DFRobot/DFRobot_RaspberryPi_Expansion_Board
+"""
+import abc
+import logging
+import time
+
+_PWM_CHAN_COUNT = 4
+_ADC_CHAN_COUNT = 4
+
+_LOG = logging.getLogger(__name__)
+
+
+class DFRobotExpansionBoard(abc.ABC):
+    """Base class for Expansion Board functionality."""
+
+    _REG_SLAVE_ADDR = 0x00
+    _REG_PID = 0x01
+    _REG_VID = 0x02
+    _REG_PWM_CONTROL = 0x03
+    _REG_PWM_FREQ = 0x04
+    _REG_PWM_DUTY1 = 0x06
+    _REG_PWM_DUTY2 = 0x08
+    _REG_PWM_DUTY3 = 0x0A
+    _REG_PWM_DUTY4 = 0x0C
+    _REG_ADC_CTRL = 0x0E
+    _REG_ADC_VAL1 = 0x0F
+    _REG_ADC_VAL2 = 0x11
+    _REG_ADC_VAL3 = 0x13
+    _REG_ADC_VAL4 = 0x15
+
+    _REG_DEF_PID = 0xDF
+    _REG_DEF_VID = 0x10
+
+    """ Enum board Analog channels """
+    A0 = 0x00
+    A1 = 0x01
+    A2 = 0x02
+    A3 = 0x03
+
+    """ Board status """
+    STA_OK = 0x00
+    STA_ERR = 0x01
+    STA_ERR_DEVICE_NOT_DETECTED = 0x02
+    STA_ERR_SOFT_VERSION = 0x03
+    STA_ERR_PARAMETER = 0x04
+
+    """ last operate status, users can use this variable to determine the result of a function call. """
+    last_operate_status = STA_OK
+
+    """ Global variables """
+    ALL = 0xFFFFFFFF
+
+    @abc.abstractmethod
+    def _write_bytes(self, reg, buf):
+        pass
+
+    @abc.abstractmethod
+    def _read_bytes(self, reg, length):
+        pass
+
+    def __init__(self, addr):
+        self._addr = addr
+        self._is_pwm_enable = False
+
+    def begin(self):
+        """
+        @brief    Board begin
+        @return   Board status
+        """
+        pid = self._read_bytes(self._REG_PID, 1)
+        vid = self._read_bytes(self._REG_VID, 1)
+        if self.last_operate_status == self.STA_OK:
+            if pid[0] != self._REG_DEF_PID:
+                self.last_operate_status = self.STA_ERR_DEVICE_NOT_DETECTED
+            elif vid[0] != self._REG_DEF_VID:
+                self.last_operate_status = self.STA_ERR_SOFT_VERSION
+            else:
+                self.set_pwm_disable()
+                self.set_pwm_duty(self.ALL, 0)
+                self.set_adc_disable()
+        return self.last_operate_status
+
+    def set_addr(self, addr):
+        """
+        @brief    Set board controler address, reboot module to make it effective
+        @param address: int    Address to set, range in 1 to 127
+        """
+        if addr < 1 or addr > 127:
+            self.last_operate_status = self.STA_ERR_PARAMETER
+            return
+        self._write_bytes(self._REG_SLAVE_ADDR, [addr])
+
+    def _parse_id(self, limit, id_):
+        ld = []
+        if isinstance(id_, list) is False:
+            id_ = id_ + 1
+            ld.append(id_)
+        else:
+            ld = [i + 1 for i in id_]
+        if ld == self.ALL:
+            return range(1, limit + 1)
+        for i in ld:
+            if i < 1 or i > limit:
+                self.last_operate_status = self.STA_ERR_PARAMETER
+                return []
+        return ld
+
+    def set_pwm_enable(self):
+        """
+        @brief    Set pwm enable, pwm channel need external power
+        """
+        self._write_bytes(self._REG_PWM_CONTROL, [0x01])
+        if self.last_operate_status == self.STA_OK:
+            self._is_pwm_enable = True
+        time.sleep(0.01)
+
+    def set_pwm_disable(self):
+        """
+        @brief    Set pwm disable
+        """
+        self._write_bytes(self._REG_PWM_CONTROL, [0x00])
+        if self.last_operate_status == self.STA_OK:
+            self._is_pwm_enable = False
+        time.sleep(0.01)
+
+    def set_pwm_frequency(self, freq):
+        """
+        @brief    Set pwm frequency
+        @param freq: int    Frequency to set, in range 1 - 1000
+        """
+        if freq < 1 or freq > 1000:
+            self.last_operate_status = self.STA_ERR_PARAMETER
+            return
+        is_pwm_enable = self._is_pwm_enable
+        self.set_pwm_disable()
+        self._write_bytes(self._REG_PWM_FREQ, [freq >> 8, freq & 0xFF])
+        time.sleep(0.01)
+        if is_pwm_enable:
+            self.set_pwm_enable()
+
+    def set_pwm_duty(self, chan, duty):
+        """
+        @brief    Set selected channel duty
+        @param chan: list     One or more channels to set, items in range 1 to 4, or chan = self.ALL
+        @param duty: float    Duty to set, in range 0.0 to 100.0
+        """
+        if duty < 0 or duty > 100:
+            self.last_operate_status = self.STA_ERR_PARAMETER
+            return
+        for i in self._parse_id(_PWM_CHAN_COUNT, chan):
+            self._write_bytes(
+                self._REG_PWM_DUTY1 + (i - 1) * 2, [int(duty), int((duty * 10) % 10)]
+            )
+
+    def set_adc_enable(self):
+        """
+        @brief    Set adc enable
+        """
+        self._write_bytes(self._REG_ADC_CTRL, [0x01])
+
+    def set_adc_disable(self):
+        """
+        @brief    Set adc disable
+        """
+        self._write_bytes(self._REG_ADC_CTRL, [0x00])
+
+    def get_adc_value(self, chan):
+        """
+        @brief    Get adc value
+        @param chan: int    Channel to get, in range 1 to 4, or self.ALL
+        @return :list       List of value
+        """
+        for i in self._parse_id(_ADC_CHAN_COUNT, chan):
+            rslt = self._read_bytes(self._REG_ADC_VAL1 + (i - 1) * 2, 2)
+        return (rslt[0] << 8) | rslt[1]
+
+    def detecte(self):
+        """
+        @brief    If you forget address you had set, use this to detecte them, must have class instance
+        @return   Board list conformed
+        """
+        l = []
+        back = self._addr
+        for i in range(1, 127):
+            self._addr = i
+            if self.begin() == self.STA_OK:
+                l.append(i)
+        l = map(hex, l)
+        self._addr = back
+        self.last_operate_status = self.STA_OK
+        return l
+
+
+class DFRobotExpansionBoardDigitalRGBLED:
+    """Class for digital RGB LED control."""
+
+    def __init__(self, board):
+        """
+        @param board: DFRobot_Expansion_Board   Board instance to operate digital rgb led, test LED: https://www.dfrobot.com/product-1829.html
+                                                Warning: LED must connect to pwm channel, otherwise may destory Pi IO
+        """
+        self._board = board
+        self._chan_r = 0
+        self._chan_g = 0
+        self._chan_b = 0
+
+    def begin(self, chan_r, chan_g, chan_b):
+        """
+        @brief    Set digital rgb led color channel, these parameters not repeat
+        @param chan_r: int    Set color red channel id, in range 1 to 4
+        @param chan_g: int    Set color green channel id, in range 1 to 4
+        @param chan_b: int    Set color blue channel id, in range 1 to 4
+        """
+        if chan_r == chan_g or chan_r == chan_b or chan_g == chan_b:
+            return
+        if (
+            chan_r < _PWM_CHAN_COUNT
+            and chan_g < _PWM_CHAN_COUNT
+            and chan_b < _PWM_CHAN_COUNT
+        ):
+            self._chan_r = chan_r
+            self._chan_g = chan_g
+            self._chan_b = chan_b
+            self._board.set_pwm_enable()
+            self._board.set_pwm_frequency(1000)
+            self._board.set_pwm_duty(self._board.ALL, 100)
+
+    def color888(self, r, g, b):
+        """
+        @brief    Set LED to true-color
+        @param r: int   Color components red
+        @param g: int   Color components green
+        @param b: int   Color components blue
+        """
+        self._board.set_pwm_duty([self._chan_r], 100 - (r & 0xFF) * 100 // 255)
+        self._board.set_pwm_duty([self._chan_g], 100 - (g & 0xFF) * 100 // 255)
+        self._board.set_pwm_duty([self._chan_b], 100 - (b & 0xFF) * 100 // 255)
+
+    def color24(self, color):
+        """
+        @brief    Set LED to 24-bits color
+        @param color: int   24-bits color
+        """
+        color &= 0xFFFFFF
+        self.color888(color >> 16, (color >> 8) & 0xFF, color & 0xFF)
+
+    def color565(self, color):
+        """
+        @brief    Set LED to 16-bits color
+        @param color: int   16-bits color
+        """
+        color &= 0xFFFF
+        self.color888((color & 0xF800) >> 8, (color & 0x7E0) >> 3, (color & 0x1F) << 3)
+
+
+class DFRobotExpansionBoardServo:
+    """Class to operate a servo"""
+
+    def __init__(self, board):
+        """
+        @param board: DFRobot_Expansion_Board   Board instance to operate servo, test servo: https://www.dfrobot.com/product-255.html
+                                                Warning: servo must connect to pwm channel, otherwise may destory Pi IO
+        """
+        self._board = board
+
+    def begin(self):
+        """
+        @brief    Board servo begin
+        """
+        self._board.set_pwm_enable()
+        self._board.set_pwm_frequency(50)
+        self._board.set_pwm_duty(self._board.ALL, 0)
+
+    def move(self, id_, angle):
+        """
+        @brief    Servos move
+        @param id_: list     One or more servos to set, items in range 1 to 4, or chan = self.ALL
+        @param angle: int   Angle to move, in range 0 to 180
+        """
+        if 0 <= angle <= 180:
+            self._board.set_pwm_duty(id_, (0.5 + (float(angle) / 90.0)) / 20 * 100)
+
+
+class DFRobotExpansionBoardIIC(DFRobotExpansionBoard):
+    """Class for IIC communication with Expansion Board."""
+
+    def __init__(self, bus_id, addr):
+        """
+        @param bus_id: int   Which bus to operate
+        @oaram addr: int     Board controler address
+        """
+        # pylint: disable=import-outside-toplevel,import-error
+        import smbus
+
+        self._bus = smbus.SMBus(bus_id)
+        super().__init__(addr)
+
+    def _write_bytes(self, reg, buf):
+        # pylint: disable=broad-exception-caught
+        self.last_operate_status = self.STA_ERR_DEVICE_NOT_DETECTED
+        try:
+            self._bus.write_i2c_block_data(self._addr, reg, buf)
+            self.last_operate_status = self.STA_OK
+        except Exception:
+            _LOG.warning("DFRobotExpansionBoardIIC I2C write error")
+
+    def _read_bytes(self, reg, length):
+        # pylint: disable=broad-exception-caught
+        self.last_operate_status = self.STA_ERR_DEVICE_NOT_DETECTED
+        try:
+            rslt = self._bus.read_i2c_block_data(self._addr, reg, length)
+            self.last_operate_status = self.STA_OK
+            return rslt
+        except Exception:
+            _LOG.warning("DFRobotExpansionBoardIIC I2C read error")
+            return [0] * length

--- a/mqtt_io/modules/sensor/drivers/DFRobot_RaspberryPi_Expansion_Board.py
+++ b/mqtt_io/modules/sensor/drivers/DFRobot_RaspberryPi_Expansion_Board.py
@@ -133,7 +133,7 @@ class DFRobotExpansionBoard(abc.ABC):
         """
         self._write_bytes(self._REG_ADC_CTRL, [0x00])
 
-    def get_adc_value(self, chan: int) -> Union[List[float], float]:
+    def get_adc_value(self, chan: int) -> float:
         """
         Return the ADC value for the given channel.
         """

--- a/mqtt_io/modules/sensor/drivers/dfr0566_driver.py
+++ b/mqtt_io/modules/sensor/drivers/dfr0566_driver.py
@@ -20,6 +20,7 @@ from typing import List
 
 BOARD_SETUP_TRIES = 3
 BOARD_SETUP_TIMEOUT = 2
+PMW_CHANNELS = 4
 
 _LOG = logging.getLogger(__name__)
 
@@ -73,7 +74,7 @@ class DFRobotExpansionBoard(abc.ABC):
         self._addr = addr
         self._is_pwm_enable = False
 
-    def begin(self) -> int:
+    def begin(self, disable_pmw: bool = False, disable_adc: bool = False) -> int:
         """
         Board begin
         return:   Board status
@@ -86,8 +87,10 @@ class DFRobotExpansionBoard(abc.ABC):
             elif vid[0] != self._REG_DEF_VID:
                 self.last_operate_status = self.STA_ERR_SOFT_VERSION
             else:
-                self.set_pwm_disable()
-                self.set_adc_disable()
+                if disable_pmw:
+                    self.set_pwm_disable()
+                if disable_adc:
+                    self.set_adc_disable()
         return self.last_operate_status
 
     def set_addr(self, addr: int) -> None:
@@ -228,10 +231,8 @@ class DFRobotExpansionBoardServo:
         """
         self._board.set_pwm_enable()
         self._board.set_pwm_frequency(50)
-        self._board.set_pwm_duty(0, 0)
-        self._board.set_pwm_duty(1, 0)
-        self._board.set_pwm_duty(2, 0)
-        self._board.set_pwm_duty(3, 0)
+        for channel in range(PMW_CHANNELS):
+            self._board.set_pwm_duty(channel, 0)
 
     def move(self, channel_id: int, angle: int) -> None:
         """

--- a/mqtt_io/modules/sensor/drivers/dfr0566_driver.py
+++ b/mqtt_io/modules/sensor/drivers/dfr0566_driver.py
@@ -4,7 +4,8 @@
   Adapted from the below by @linucks
 
   @file DFRobot_RaspberryPi_Expansion_Board.py
-  @brief This RaspberryPi expansion board can communicate with RaspberryPi via I2C. It has 10 GPIOs, 1 SPI, 4 I2Cs and 1 uart.
+  @brief This RaspberryPi expansion board can communicate with RaspberryPi via I2C.
+         It has 10 GPIOs, 1 SPI, 4 I2Cs and 1 uart.
   @copyright   Copyright (c) 2010 DFRobot Co.Ltd (http://www.dfrobot.com)
   @license     The MIT License (MIT)
   @author      Frank(jiehan.guo@dfrobot.com)
@@ -15,7 +16,7 @@
 import abc
 import logging
 import time
-from typing import List, Union
+from typing import List
 
 _PWM_CHAN_COUNT = 4
 _ADC_CHAN_COUNT = 4
@@ -59,7 +60,7 @@ class DFRobotExpansionBoard(abc.ABC):
     STA_ERR_SOFT_VERSION = 0x03
     STA_ERR_PARAMETER = 0x04
 
-    """ last operate status, users can use this variable to determine the result of a function call. """
+    """Last operation status: use this variable to determine the result of a function call. """
     last_operate_status = STA_OK
 
     @abc.abstractmethod

--- a/mqtt_io/modules/sensor/flowsensor.py
+++ b/mqtt_io/modules/sensor/flowsensor.py
@@ -33,6 +33,8 @@ If you use "factor = 1", the sensor module returns the frequency in Hertz (Hz).
 """
 
 from typing import Dict
+
+from mqtt_io.events import EventBus
 from ...types import CerberusSchemaType, ConfigType, SensorValueType
 from . import GenericSensor
 
@@ -45,7 +47,7 @@ class FLOWSENSOR:
     Multiple instances support multiple sensors on different pins
     """
 
-    def __init__(self, gpiozero, name: str, pin: int) -> None: # type: ignore[no-untyped-def]
+    def __init__(self, gpiozero, name: str, pin: int) -> None:  # type: ignore[no-untyped-def]
         self.name = name
         self.pin = gpiozero.DigitalInputDevice(pin)
         self.pin.when_activated = self.count_pulse
@@ -75,7 +77,7 @@ class FLOWSENSOR:
 
     def get_value(self, interval: int, factor: float) -> float:
         """Return flow rate in L/min over interval seconds and reset count."""
-        flow_rate = self.flow_rate(interval,factor)
+        flow_rate = self.flow_rate(interval, factor)
         self.reset_count()
         return flow_rate
 
@@ -87,20 +89,20 @@ class Sensor(GenericSensor):
 
     SENSOR_SCHEMA: CerberusSchemaType = {
         "pin": {
-            "type": 'integer',
+            "type": "integer",
             "required": True,
             "empty": False,
         },
         "interval": {
-            "type": 'integer',
+            "type": "integer",
             "required": True,
             "empty": False,
         },
         "factor": {
-            "type": 'float',
+            "type": "float",
             "required": True,
             "empty": False,
-        }
+        },
     }
 
     def setup_module(self) -> None:
@@ -110,11 +112,13 @@ class Sensor(GenericSensor):
         self.gpiozero = gpiozero
         self.sensors: Dict[str, FLOWSENSOR] = {}
 
-    def setup_sensor(self, sens_conf: ConfigType) -> None:
+    def setup_sensor(self, sens_conf: ConfigType, event_bus: EventBus) -> None:
         sensor = FLOWSENSOR(
             gpiozero=self.gpiozero, name=sens_conf["name"], pin=sens_conf["pin"]
         )
         self.sensors[sensor.name] = sensor
 
     def get_value(self, sens_conf: ConfigType) -> SensorValueType:
-        return self.sensors[sens_conf["name"]].get_value(sens_conf["interval"],sens_conf["factor"])
+        return self.sensors[sens_conf["name"]].get_value(
+            sens_conf["interval"], sens_conf["factor"]
+        )

--- a/mqtt_io/modules/sensor/frequencycounter.py
+++ b/mqtt_io/modules/sensor/frequencycounter.py
@@ -18,6 +18,8 @@ sensor_inputs:
 """
 
 from typing import Dict
+
+from mqtt_io.events import EventBus
 from ...types import CerberusSchemaType, ConfigType, SensorValueType
 from . import GenericSensor
 
@@ -30,7 +32,7 @@ class FREQUENCYCOUNTER:
     Multiple instances support multiple sensors on different pins
     """
 
-    def __init__(self, gpiozero, name: str, pin: int) -> None: # type: ignore[no-untyped-def]
+    def __init__(self, gpiozero, name: str, pin: int) -> None:  # type: ignore[no-untyped-def]
         self.name = name
         self.pin = gpiozero.DigitalInputDevice(pin)
         self.pin.when_activated = self.count_pulse
@@ -65,15 +67,15 @@ class Sensor(GenericSensor):
 
     SENSOR_SCHEMA: CerberusSchemaType = {
         "pin": {
-            "type": 'integer',
+            "type": "integer",
             "required": True,
             "empty": False,
         },
         "interval": {
-            "type": 'integer',
+            "type": "integer",
             "required": True,
             "empty": False,
-        }
+        },
     }
 
     def setup_module(self) -> None:
@@ -83,7 +85,7 @@ class Sensor(GenericSensor):
         self.gpiozero = gpiozero
         self.sensors: Dict[str, FREQUENCYCOUNTER] = {}
 
-    def setup_sensor(self, sens_conf: ConfigType) -> None:
+    def setup_sensor(self, sens_conf: ConfigType, event_bus: EventBus) -> None:
         sensor = FREQUENCYCOUNTER(
             gpiozero=self.gpiozero, name=sens_conf["name"], pin=sens_conf["pin"]
         )

--- a/mqtt_io/modules/sensor/hcsr04.py
+++ b/mqtt_io/modules/sensor/hcsr04.py
@@ -6,6 +6,8 @@ import time
 from statistics import mean
 from typing import Any, Dict, List, Optional
 
+from mqtt_io.events import EventBus
+
 from ...types import CerberusSchemaType, ConfigType, SensorValueType
 from . import GenericSensor
 
@@ -123,7 +125,7 @@ class Sensor(GenericSensor):
         self.gpio = GPIO
         self.sensors: Dict[str, HCSR04] = {}
 
-    def setup_sensor(self, sens_conf: ConfigType) -> None:
+    def setup_sensor(self, sens_conf: ConfigType, event_bus: EventBus) -> None:
         sensor = HCSR04(gpio=self.gpio, **sens_conf)
         self.sensors[sensor.name] = sensor
 

--- a/mqtt_io/modules/sensor/mock.py
+++ b/mqtt_io/modules/sensor/mock.py
@@ -4,11 +4,13 @@ Mock Sensor module for use with the tests.
 
 from unittest.mock import Mock
 
+from mqtt_io.events import EventBus
+
 from ...types import ConfigType, SensorValueType
 from . import GenericSensor
 
 REQUIREMENTS = ()
-CONFIG_SCHEMA = {"test": {"type": 'boolean', "required": False, "default": False}}
+CONFIG_SCHEMA = {"test": {"type": "boolean", "required": False, "default": False}}
 
 
 # pylint: disable=useless-super-delegation
@@ -26,8 +28,8 @@ class Sensor(GenericSensor):
     def setup_module(self) -> None:
         return super().setup_module()
 
-    def setup_sensor(self, sens_conf: ConfigType) -> None:
-        return super().setup_sensor(sens_conf)
+    def setup_sensor(self, sens_conf: ConfigType, event_bus: EventBus) -> None:
+        return super().setup_sensor(sens_conf, event_bus)
 
     def get_value(self, sens_conf: ConfigType) -> SensorValueType:
         return super().get_value(sens_conf)

--- a/mqtt_io/modules/sensor/pms5003.py
+++ b/mqtt_io/modules/sensor/pms5003.py
@@ -9,7 +9,7 @@ from . import GenericSensor
 
 REQUIREMENTS = ("plantower",)
 CONFIG_SCHEMA: CerberusSchemaType = {
-    "serial_port": {"type": 'string', "required": True, "empty": False},
+    "serial_port": {"type": "string", "required": True, "empty": False},
 }
 
 
@@ -20,33 +20,42 @@ class Sensor(GenericSensor):
 
     SENSOR_SCHEMA: CerberusSchemaType = {
         "type": {
-            "type": 'string',
+            "type": "string",
             "required": False,
             "empty": False,
-            "default": 'pm25_std',
-            "allowed": 
-                ['pm10_cf1', 'pm25_cf1','pm100_cf1',
-                 'pm10_std','pm25_std','pm100_std',
-                 'gr03um','gr05um','gr10um',
-                 'gr25um','gr50um','gr100um'],
+            "default": "pm25_std",
+            "allowed": [
+                "pm10_cf1",
+                "pm25_cf1",
+                "pm100_cf1",
+                "pm10_std",
+                "pm25_std",
+                "pm100_std",
+                "gr03um",
+                "gr05um",
+                "gr10um",
+                "gr25um",
+                "gr50um",
+                "gr100um",
+            ],
         }
     }
 
     def setup_module(self) -> None:
         # pylint: disable=import-outside-toplevel,import-error
-        import plantower # type: ignore
+        import plantower  # type: ignore
 
         self.serial_port = self.config["serial_port"]
         self.sensor = plantower.Plantower(port=self.serial_port)
         self.sensor.mode_change(plantower.PMS_PASSIVE_MODE)
         self.sensor.set_to_wakeup()
-        time.sleep(30) #give fan time to stabilize readings
+        time.sleep(30)  # give fan time to stabilize readings
 
     def get_value(self, sens_conf: ConfigType) -> SensorValueType:
         """
         Get the particulate data from the sensor
         """
-        #turn sensor off if interval between readings is >= 2 minutes
+        # turn sensor off if interval between readings is >= 2 minutes
         sleep_sensor = sens_conf["interval"] >= 120
         if sleep_sensor:
             self.sensor.set_to_wakeup()
@@ -69,8 +78,8 @@ class Sensor(GenericSensor):
                 "gr10um": result.gr10um,
                 "gr25um": result.gr25um,
                 "gr50um": result.gr50um,
-                "gr100u": result.gr100um
-                }[sens_type],
+                "gr100u": result.gr100um,
+            }[sens_type],
         )
 
     def cleanup(self) -> None:

--- a/mqtt_io/modules/sensor/yfs201.py
+++ b/mqtt_io/modules/sensor/yfs201.py
@@ -17,6 +17,8 @@ sensor_inputs:
 """
 
 from typing import Dict
+
+from mqtt_io.events import EventBus
 from ...types import CerberusSchemaType, ConfigType, SensorValueType
 from . import GenericSensor
 
@@ -29,7 +31,7 @@ class YFS201:
     Multiple instances support multiple sensors on different pins
     """
 
-    def __init__(self, gpiozero, name: str, pin: int) -> None: # type: ignore[no-untyped-def]
+    def __init__(self, gpiozero, name: str, pin: int) -> None:  # type: ignore[no-untyped-def]
         self.name = name
         self.pin = gpiozero.DigitalInputDevice(pin)
         self.pin.when_activated = self.count_pulse
@@ -71,7 +73,7 @@ class Sensor(GenericSensor):
 
     SENSOR_SCHEMA: CerberusSchemaType = {
         "pin": {
-            "type": 'integer',
+            "type": "integer",
             "required": True,
             "empty": False,
         }
@@ -84,7 +86,7 @@ class Sensor(GenericSensor):
         self.gpiozero = gpiozero
         self.sensors: Dict[str, YFS201] = {}
 
-    def setup_sensor(self, sens_conf: ConfigType) -> None:
+    def setup_sensor(self, sens_conf: ConfigType, event_bus: EventBus) -> None:
         sensor = YFS201(
             gpiozero=self.gpiozero, name=sens_conf["name"], pin=sens_conf["pin"]
         )

--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -628,7 +628,7 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
             )
             self.sensor_input_configs[sens_conf["name"]] = sens_conf
 
-            sensor_module.setup_sensor(sens_conf)
+            sensor_module.setup_sensor(sens_conf, self.event_bus)
 
             # Use default args to the function to get around the late binding closures
             async def poll_sensor(


### PR DESCRIPTION
This adds support for the [DFRobot EC sensor](https://wiki.dfrobot.com/Gravity__Analog_Electrical_Conductivity_Sensor___Meter_V2__K%3D1__SKU_DFR0300). 

In order to give an accurate reading, the EC sensor requires  the current  temperature. This PR also adds the EventBus argument to the setup_sensor function, so that sensors can query the event bus and read the value of other sensors. This has required changing the setup_sensor call for all sensors.

For the sensor to function properly, it needs to be plugged into an ADC. The DFRobot [DRF0566](https://wiki.dfrobot.com/IO%20Expansion%20HAT%20for%20Raspberry%20Pi%20%20SKU:%20%20DFR0566#target_5) HAT has the correct connectors and an integral ADC, so this PR includes the addition of the code for the HAT and the ADC in the `mqtt_io/modules/sensor/drivers` folder. This is added separately so that it can be used by other sensors as there are many sensors from DFRobot that could be added trivially using this driver.

