### PR TITLE
WIP: Generate README.md from template

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Hardware support is provided by specific GPIO, Sensor and Stream modules. It's e
 ### GPIO Modules
 
   - Beaglebone GPIO (`beaglebone`)
+  - DockerPi 4 Channel Relay GPIO (`dockerpi`)
   - Linux Kernel 4.8+ libgpiod (`gpiod`)
   - GPIO Zero (`gpiozero`)
   - MCP23017 IO expander (`mcp23017`)
@@ -27,35 +28,38 @@ Hardware support is provided by specific GPIO, Sensor and Stream modules. It's e
   - PCF8575 IO expander (`pcf8575`)
   - PiFace Digital IO 2 (`piface2`)
   - Raspberry Pi GPIO (`raspberrypi`)
+  - Sunxi Board (`sunxi`)
 
 ### Sensors
 
   - ADS1x15 analog to digital converters (`ads1x15`)
+  - ADXL345 Digital Accelerometer Sensor (`adxl345`)
   - AHT20 temperature and humidity sensor (`aht20`)
   - BH1750 light level sensor (`bh1750`)
   - BME280 temperature, humidity and pressure sensor (`bme280`)
   - BME680 temperature, humidity and pressure sensor (`bme680`)
+  - BMP085 temperature and pressure sensor (`bmp085`)
   - DHT11/DHT22/AM2302 temperature and humidity sensors (`dht22`)
   - DS18S20/DS1822/DS18B20/DS1825/DS28EA00/MAX31850K temperature sensors (`ds18b`)
-  - ENS160  digital multi-gas sensor with multiple IAQ data (TVOC, eCO2, AQI) (`ens160`)
-  - FREQUENCYCOUNTER Counts pulses from GPIOs and return the frequency in Hz (`frequencycounterr`)
-  - FLOWSENSOR generic flow rate sensor like YF-S201, YF-DN50 or others (`flowsensor`)
+  - ENS160 Air Quality Sensor (`ens160`)
+  - Flowsensor: Generic Flow Rate Sensor (`flowsensor`)
+  - Frequencycounter: Generic Frequency Counter (`frequencycounter`)
   - HCSR04 ultrasonic range sensor (connected to the Raspberry Pi on-board GPIO) (`hcsr04`)
   - INA219 DC current sensor (`ina219`)
   - LM75 temperature sensor (`lm75`)
   - MCP3008 analog to digital converter (`mcp3008`)
-  - ADXl345 3-axis accelerometer up to ±16g  (`adxl345`)
-  - PMS5003 particulate sensor (`pms5003`)
-  - SHT40/SHT41/SHT45 temperature and humidity sensors (`sht4x`)
-  - TLSl2561 light level sensor (`tsl2561`)
-  - VEML7700 light level sensor (`veml7700`)
-  - YF-S201 flow rate sensor (`yfs201`)
-
+  - MCP3xxx analog to digital converter via GPIOZero (`mcp3xxx`)
+  - MH-Z19 NDIR CO2 sensor (`mhz19`)
+  - PMS5003 Particulate Matter Sensor (`pms5003`)
+  - SHT4x temperature and humidity sensor (`sht4x`)
+  - TSL2561 luminosity sensor (`tsl2561`)
+  - VEML 6075 UV sensor (`veml6075`)
+  - VEML7700 luminosity sensor (`veml7700`)
 
 ### Streams
 
-  - Serial port (`serial`)
   - PN532 NFC/RFID reader (`pn532`)
+  - Serial port (`serial`)
 
 ## Installation
 
@@ -111,30 +115,11 @@ sensor_modules:
     module: lm75
     i2c_bus_num: 1
     chip_addr: 0x48
-  # An INA219 sensor attached to the I2C bus
-  - name: ina219_sensor
-    module: ina219
-    i2c_bus_num: 1
-    chip_addr: 0x43
-
 
 sensor_inputs:
-  # lm75 - The configuration of the specific sensor value to use (LM75 only has temperature)
+  # The configuration of the specific sensor value to use (LM75 only has temperature)
   - name: porch_temperature
     module: lm75_sensor
-  # ina219 - The configuration of the specific sensor value to use (4 options for the ina219 sensor)
-  - name: power
-    type: power
-    module: ina219_sensor
-  - name: bus_voltage
-    type: bus_voltage
-    module: ina219_sensor
-  - name: current
-    type: current
-    module: ina219_sensor
-  - name: shunt_voltage
-    type: shunt_voltage
-    module: ina219_sensor
 
 # Streams
 stream_modules:

--- a/README.md.j2
+++ b/README.md.j2
@@ -101,3 +101,4 @@ stream_modules:
     device: /dev/ttyUSB0
     baud: 9600
 ```
+

--- a/mqtt_io/modules/sensor/adxl345.py
+++ b/mqtt_io/modules/sensor/adxl345.py
@@ -1,26 +1,23 @@
 """
 ADXL345 Digital Accelerometer Sensor
 """
-
-"""
-
-Mandatory:
-- chip_addr
-
-Optional:
-- output_g (set True if output in g). default:m*s²
-
-Output:
-- x (in m*s²)
-- y (in m*s²)
-- z (in m*s²)
-"""
-
 from json import dumps
 from typing import cast
 
 from ...types import CerberusSchemaType, ConfigType, SensorValueType
 from . import GenericSensor
+
+## Mandatory:
+## - chip_addr
+##
+## Optional:
+## - output_g (set True if output in g). default:m*s²
+##
+## Output:
+## - x (in m*s²)
+## - y (in m*s²)
+## - z (in m*s²)
+
 
 REQUIREMENTS = ("adxl345",)
 CONFIG_SCHEMA: CerberusSchemaType = {

--- a/mqtt_io/modules/sensor/adxl345.py
+++ b/mqtt_io/modules/sensor/adxl345.py
@@ -1,5 +1,8 @@
 """
 ADXL345 Digital Accelerometer Sensor
+"""
+
+"""
 
 Mandatory:
 - chip_addr

--- a/mqtt_io/modules/sensor/ens160.py
+++ b/mqtt_io/modules/sensor/ens160.py
@@ -1,5 +1,8 @@
 """
 ENS160 Air Quality Sensor
+"""
+
+"""
 
 sensor_modules:
   - name: ens160

--- a/mqtt_io/modules/sensor/ens160.py
+++ b/mqtt_io/modules/sensor/ens160.py
@@ -1,40 +1,37 @@
 """
 ENS160 Air Quality Sensor
 """
-
-"""
-
-sensor_modules:
-  - name: ens160
-    module: ens160
-    chip_addr: 0x53
-    temperature_compensation: 25
-    humidity_compensation: 50
-
-sensor_inputs:
-  - name: air_quality
-    module: ens160
-    interval: 10
-    digits: 0
-    type: aqi
-
-  - name: volatile_organic_compounds
-    module: ens160
-    interval: 10
-    digits: 0
-    type: tvoc
-
-  - name: eco2
-    module: ens160
-    interval: 10
-    digits: 0
-    type: eco2
-"""
-
 from typing import cast
 
 from ...types import CerberusSchemaType, ConfigType
 from . import GenericSensor
+
+## Example configuration:
+##sensor_modules:
+##  - name: ens160
+##    module: ens160
+##    chip_addr: 0x53
+##    temperature_compensation: 25
+##    humidity_compensation: 50
+##
+##sensor_inputs:
+##  - name: air_quality
+##    module: ens160
+##    interval: 10
+##    digits: 0
+##    type: aqi
+##
+##  - name: volatile_organic_compounds
+##    module: ens160
+##    interval: 10
+##    digits: 0
+##    type: tvoc
+##
+##  - name: eco2
+##    module: ens160
+##    interval: 10
+##    digits: 0
+##    type: eco2
 
 DEFAULT_CHIP_ADDR = 0x53
 DEFAULT_TEMPERATURE_COMPENSATION = 25

--- a/mqtt_io/modules/sensor/flowsensor.py
+++ b/mqtt_io/modules/sensor/flowsensor.py
@@ -1,42 +1,37 @@
 """
 Flowsensor: Generic Flow Rate Sensor
 """
-
-"""
-
-Example configuration:
-
-sensor_modules:
-  - name: yfs201
-    module: flowsensor
-
-sensor_inputs:
-  - name: flow_rate1
-    module: yfs201
-    pin: 0
-    digits: 0
-    interval: 10
-    factor: 0.2
-
-Factor can be calculated from Pulse characteristcs (dicumentation):
-
-From YF-S201 manual:
-  Pulse Characteristic: F = 7 * Q (L/MIN).
-  Pulse frequency (Hz) / 7.0 = flow rate in L/min
-  ==> Factor = 7.0
-
-From YF-DN50 manual:
-  Pulse Characteristic: F = 0.2 * Q (L/MIN).
-  Pulse frequency (Hz) / 0.2 = flow rate in L/min
-  ==> Factor = 0.2
-
-If you use "factor = 1", the sensor module returns the frequency in Hertz (Hz).
-
-"""
-
 from typing import Dict
 from ...types import CerberusSchemaType, ConfigType, SensorValueType
 from . import GenericSensor
+
+## Example configuration:
+##sensor_modules:
+##  - name: yfs201
+##    module: flowsensor
+##
+##sensor_inputs:
+##  - name: flow_rate1
+##    module: yfs201
+##    pin: 0
+##    digits: 0
+##    interval: 10
+##    factor: 0.2
+##
+##Factor can be calculated from Pulse characteristcs (dicumentation):
+##
+##From YF-S201 manual:
+##  Pulse Characteristic: F = 7 * Q (L/MIN).
+##  Pulse frequency (Hz) / 7.0 = flow rate in L/min
+##  ==> Factor = 7.0
+##
+##From YF-DN50 manual:
+##  Pulse Characteristic: F = 0.2 * Q (L/MIN).
+##  Pulse frequency (Hz) / 0.2 = flow rate in L/min
+##  ==> Factor = 0.2
+##
+##If you use "factor = 1", the sensor module returns the frequency in Hertz (Hz).
+
 
 REQUIREMENTS = ("gpiozero",)
 

--- a/mqtt_io/modules/sensor/flowsensor.py
+++ b/mqtt_io/modules/sensor/flowsensor.py
@@ -1,6 +1,8 @@
 """
-
 Flowsensor: Generic Flow Rate Sensor
+"""
+
+"""
 
 Example configuration:
 

--- a/mqtt_io/modules/sensor/frequencycounter.py
+++ b/mqtt_io/modules/sensor/frequencycounter.py
@@ -1,27 +1,23 @@
 """
 Frequencycounter: Generic Frequency Counter
 """
-
-"""
-
-Example configuration:
-
-sensor_modules:
-  - name: frequency
-    module: frequencycounter
-
-sensor_inputs:
-  - name: flow_rate1
-    module: frequency
-    pin: 0
-    digits: 0
-    interval: 10
-
-"""
-
 from typing import Dict
 from ...types import CerberusSchemaType, ConfigType, SensorValueType
 from . import GenericSensor
+
+##Example configuration:
+##
+##sensor_modules:
+##  - name: frequency
+##    module: frequencycounter
+##
+##sensor_inputs:
+##  - name: flow_rate1
+##    module: frequency
+##    pin: 0
+##    digits: 0
+##    interval: 10
+
 
 REQUIREMENTS = ("gpiozero",)
 

--- a/mqtt_io/modules/sensor/frequencycounter.py
+++ b/mqtt_io/modules/sensor/frequencycounter.py
@@ -1,6 +1,8 @@
 """
-
 Frequencycounter: Generic Frequency Counter
+"""
+
+"""
 
 Example configuration:
 


### PR DESCRIPTION
According to the logic behind the template https://github.com/flyte/mqtt-io/blob/develop/README.md.j2 README should be generated from this template.

I've tried to generate it but there are a lot of changes.

* I was able to fix some huge changes by separating `module` description and samples to two comment blocks.
* It seems it was edited manually before.
* There are two READMEs with the different content https://github.com/flyte/mqtt-io/blob/develop/README.md and https://github.com/flyte/mqtt-io/blob/develop/docs_src/README.md

I think the template should be modified to match actual README.