### PR TITLE
feat: use host/user/pass from env vars #406

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ _Requires Python 3.6+_
 
 `python3 -m mqtt_io config.yml`
 
+Some configuration parameters can be passed as environment variables:
+
+- `MQTT_IO_HOST` - Host name or IP address of the MQTT server.
+- `MQTT_IO_PORT` - Port number to connect to on the MQTT server.
+- `MQTT_IO_USER` - Username to authenticate with on the MQTT server.
+- `MQTT_IO_PASSWORD` - Password to authenticate with on the MQTT server.
+- `MQTT_IO_PROTOCOL` - Version of the MQTT protocol to use.
+
+Environment variables take precedence over configuration files.
+
 ## Configuration Example
 
 Configuration is written in a YAML file which is passed as an argument to the server on startup.

--- a/mqtt_io/__main__.py
+++ b/mqtt_io/__main__.py
@@ -4,6 +4,7 @@ Main entrypoint when MQTT IO is invoked as `python -m mqtt_io`.
 import argparse
 import logging.config
 import sys
+from os import getenv
 from copy import deepcopy
 from hashlib import sha256
 from typing import Any, Optional
@@ -76,6 +77,16 @@ def main() -> None:
     # Load, validate and normalise config, or quit.
     try:
         raw_config = load_config(args.config, args.render)
+        if raw_config:
+            if "mqtt" not in raw_config or raw_config["mqtt"] is None:
+                raw_config["mqtt"] = {}
+            raw_config["mqtt"]["host"] = getenv("MQTT_IO_HOST", raw_config["mqtt"].get("host"))
+            raw_config["mqtt"]["port"] = getenv("MQTT_IO_PORT", raw_config["mqtt"].get("port"))
+            raw_config["mqtt"]["user"] = getenv("MQTT_IO_USER", raw_config["mqtt"].get("user"))
+            raw_config["mqtt"]["password"] = getenv("MQTT_IO_PASSWORD",
+                                                    raw_config["mqtt"].get("password"))
+            raw_config["mqtt"]["protocol"] = getenv("MQTT_IO_PROTOCOL",
+                                                    raw_config["mqtt"].get("protocol"))
         config = validate_and_normalise_main_config(raw_config)
     except ConfigValidationFailed as exc:
         print(str(exc), file=sys.stderr)


### PR DESCRIPTION
Feature description: https://github.com/flyte/mqtt-io/issues/406

* It is not a breaking change
* Config parsing kept as is
* Config validation kept as is
* Environment variables has precedence over config

I think it is simplest way to bring this feature to mqtt-io