### PR TITLE
New sensor MPU6050

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ celerybeat-schedule
 .env
 
 # virtualenv
+.venv/
 venv/
 ENV/
 
@@ -101,4 +102,3 @@ ENV/
 
 # User's Config File
 config.yml
-

--- a/mqtt_io/config/config.schema.yml
+++ b/mqtt_io/config/config.schema.yml
@@ -283,7 +283,7 @@ gpio_modules:
       gpio_modules:
         - name: rpi_gpio
           module: raspberrypi
-        
+
         - name: pcf
           module: pcf8574
           i2c_bus_num: 1
@@ -333,7 +333,7 @@ sensor_modules:
           module: dht22
           type: AM2302
           pin: 4
-        
+
         - name: ds
           module: ds18b
           type: DS18S20
@@ -465,7 +465,7 @@ digital_inputs:
       gpio_modules:
         - name: rpi
           module: raspberrypi
-      
+
       digital_inputs:
         - name: gpio0
           module: rpi
@@ -684,7 +684,7 @@ digital_outputs:
       gpio_modules:
         - name: rpi
           module: raspberrypi
-      
+
       digital_outputs:
         - name: gpio0
           module: rpi
@@ -854,7 +854,7 @@ sensor_inputs:
           module: dht22
           type: AM2302
           pin: 4
-      
+
       sensor_inputs:
         - name: workshop_temp
           module: dht
@@ -900,10 +900,10 @@ sensor_inputs:
         meta:
           description: How long to wait between checking the value of this sensor.
           unit: seconds
-        type: integer
+        type: float
         required: no
         default: 60
-        min: 1
+        min: 0.1
       digits:
         meta:
           description: How many decimal places to round the sensor reading to.

--- a/mqtt_io/modules/sensor/mpu6050.py
+++ b/mqtt_io/modules/sensor/mpu6050.py
@@ -1,0 +1,117 @@
+"""
+MPU-6050 Gyroscope / Accelerometer Sensor
+
+Mandatory:
+- chip_addr
+
+Output:
+- x (in m*s²)
+- y (in m*s²)
+- z (in m*s²)
+"""
+
+from json import dumps
+from typing import cast
+import smbus
+import math
+import json
+
+from ...types import CerberusSchemaType, ConfigType, SensorValueType
+from . import GenericSensor
+from ...exceptions import RuntimeConfigError
+import logging
+
+_LOG = logging.getLogger(__name__)
+
+REQUIREMENTS = ("mpu6050",)
+CONFIG_SCHEMA: CerberusSchemaType = {
+    "chip_addr": {"type": 'integer', "required": True, "empty": False},
+}
+
+# MPU6050 Registers
+
+MPU6050_PWR_MGMT_1 = 0x6B
+MPU6050_TEMP_OUT_H = 0x41
+MPU6050_ACCEL_XOUT_H = 0x3B
+MPU6050_ACCEL_YOUT_H = 0x3D
+MPU6050_ACCEL_ZOUT_H = 0x3F
+MPU6050_GYRO_XOUT_H = 0x43
+MPU6050_GYRO_YOUT_H = 0x45
+MPU6050_GYRO_ZOUT_H = 0x47
+
+# =============================================================================
+
+class Sensor(GenericSensor):
+    """
+    Implementation of Sensor class for the MPU6050 sensor.
+    """
+
+    SENSOR_SCHEMA: CerberusSchemaType = {
+        "type": {
+            "type": 'list',
+            "required": False,
+            "empty": False,
+            "default": ['gyro', "angle"],
+            "allowed": ['gyro', 'angle', 'accel', 'temp', 'all'],
+        },
+    }
+
+    def setup_module(self) -> None:
+        self.i2c_addr: int = self.config["chip_addr"]
+        self.sensor = smbus.SMBus(1)  # or 0 for RPi 1
+        self.sensor.write_byte_data(self.i2c_addr, MPU6050_PWR_MGMT_1, 0)
+
+    def get_value(self, sens_conf: ConfigType) -> SensorValueType:
+        sens_type = sens_conf["type"]
+
+        # Read raw data from the sensor
+        def read_raw_data(addr):
+            # Read raw data in a single transaction
+            high = self.sensor.read_i2c_block_data(self.i2c_addr, addr, 2)
+            value = (high[0] << 8) | high[1]
+            if value > 32768:
+                value -= 65536
+            return value
+
+        # Read sensor data
+        accel_x, accel_y, accel_z = [read_raw_data(addr) for addr in (MPU6050_ACCEL_XOUT_H, MPU6050_ACCEL_YOUT_H, MPU6050_ACCEL_ZOUT_H)]
+        gyro_x, gyro_y, gyro_z = [read_raw_data(addr) for addr in (MPU6050_GYRO_XOUT_H, MPU6050_GYRO_YOUT_H, MPU6050_GYRO_ZOUT_H)]
+        temp = read_raw_data(MPU6050_TEMP_OUT_H)
+
+        # Calculate angles
+        x_angle = math.atan(accel_x / 16384.0) * (180 / math.pi)
+        y_angle = math.atan(accel_y / 16384.0) * (180 / math.pi)
+
+        # Prepare data dictionary
+        data_gyro = {
+            "gyro_x": gyro_x,
+            "gyro_y": gyro_y,
+            "gyro_z": gyro_z,
+        }
+
+        data_angle = {
+            "angle_x": x_angle,
+            "angle_y": y_angle,
+        }
+
+        data_accel= {
+            "accel_x": accel_x,
+            "accel_y": accel_y,
+            "accel_z": accel_z,
+        }
+
+        data_temp= {
+            "temp": (temp / 340.0) + 36.53  # Temperature formula for MPU6050
+        }
+
+        data = {}
+        if "gyro" in sens_type or "all" in sens_type:
+            data.update(data_gyro)
+        if "angle" in sens_type or "all" in sens_type:
+            data.update(data_angle)
+        if "accel" in sens_type or "all" in sens_type:
+            data.update(data_accel)
+        if "temp" in sens_type or "all" in sens_type:
+            data.update(data_temp)
+
+        return data

--- a/mqtt_io/server.py
+++ b/mqtt_io/server.py
@@ -22,6 +22,7 @@ from aiomqtt import MqttCodeError
 
 import backoff
 from typing_extensions import Literal
+import json
 
 from .config import (
     get_main_schema_section,
@@ -611,7 +612,9 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
                                     event.sensor_name,
                                 )
                             ),
-                            f"{event.value:.{digits}f}".encode("utf8"),
+                            # If value_type is object, then convert to JSON string
+                            json.dumps(event.value).encode("utf8") if isinstance(event.value, dict) else
+                                f"{event.value:.{digits}f}".encode("utf8"),
                             retain=sens_conf["retain"],
                         )
                     ),
@@ -681,7 +684,9 @@ class MqttIo:  # pylint: disable=too-many-instance-attributes
                             sens_conf["name"],
                         )
                     if value is not None:
-                        value = round(value, sens_conf["digits"])
+                        # If value is type object skip rounding
+                        if not isinstance(value, dict):
+                            value = round(value, sens_conf["digits"])
                         _LOG.info(
                             "Read sensor '%s' value of %s", sens_conf["name"], value
                         )


### PR DESCRIPTION

This pull request includes significant updates to the sensor configuration and implementation, particularly for the MPU-6050 sensor, as well as improvements to the handling of sensor data in the server module. The changes enhance the flexibility and functionality of the sensor system.

### Sensor Configuration and Implementation:

* [`mqtt_io/config/config.schema.yml`](diffhunk://#diff-056b978a0c33cb2c83467999662c37e02ff16c51e95a0f75c46b8f54b303c4edL903-R906): Updated the `sensor_inputs` configuration to allow floating-point values for the interval and reduced the minimum value to 0.1 seconds.
* [`mqtt_io/modules/sensor/mpu6050.py`](diffhunk://#diff-cf7282230069eacc04034f4f0e72077594f47980acc9b516c25cb71743e7e17fR1-R117): Added a new implementation for the MPU-6050 Gyroscope/Accelerometer sensor, including configuration schema, initialization, and data reading methods.

### Server Module Enhancements:

* [`mqtt_io/server.py`](diffhunk://#diff-27b6e9e2104c34adaa60de55ef26fa3f9e9eb3859eba1574bbcf6f4e4f4066acR25): Added JSON import to support new functionality.
* [`mqtt_io/server.py`](diffhunk://#diff-27b6e9e2104c34adaa60de55ef26fa3f9e9eb3859eba1574bbcf6f4e4f4066acR615-R616): Modified `publish_sensor_callback` to convert sensor values to JSON strings if they are dictionaries.
* [`mqtt_io/server.py`](diffhunk://#diff-27b6e9e2104c34adaa60de55ef26fa3f9e9eb3859eba1574bbcf6f4e4f4066acR687-R688): Updated `get_sensor_value` to skip rounding if the sensor value is a dictionary.

Sensor config:

```yaml
sensor_modules:

  - name: mpu6050
    module: mpu6050
    chip_addr: 0x69

sensor_inputs:

  - name: gyro
    module: mpu6050
    interval: 0.1
```

Sensor output:

```
2025-02-05 09:31:34 mqtt_io.server [INFO] Read sensor 'gyro' value of {'gyro_x': -280, 'gyro_y': 102, 'gyro_z': 94, 'angle_x': 2.9907613976619283, 'angle_y': -2.934957982527787}
2025-02-05 09:31:34 mqtt_io.server [INFO] Read sensor 'gyro' value of {'gyro_x': -307, 'gyro_y': 110, 'gyro_z': 89, 'angle_x': 3.2418049788882777, 'angle_y': -2.5581444189852265}
2025-02-05 09:31:34 mqtt_io.server [INFO] Read sensor 'gyro' value of {'gyro_x': -287, 'gyro_y': 111, 'gyro_z': 74, 'angle_x': 3.1441911935503275, 'angle_y': -2.6698174414062046}
2025-02-05 09:31:34 mqtt_io.server [INFO] Read sensor 'gyro' value of {'gyro_x': -299, 'gyro_y': 98, 'gyro_z': 99, 'angle_x': 3.032610238196618, 'angle_y': -2.7116896376607555}
2025-02-05 09:31:34 mqtt_io.server [INFO] Read sensor 'gyro' value of {'gyro_x': -273, 'gyro_y': 136, 'gyro_z': 105, 'angle_x': 3.032610238196618, 'angle_y': -2.61398341444651}
2025-02-05 09:31:34 mqtt_io.server [INFO] Read sensor 'gyro' value of {'gyro_x': -287, 'gyro_y': 126, 'gyro_z': 113, 'angle_x': 2.8512424422652436, 'angle_y': -2.76751471624175}
2025-02-05 09:31:35 mqtt_io.server [INFO] Read sensor 'gyro' value of {'gyro_x': -296, 'gyro_y': 129, 'gyro_z': 114, 'angle_x': 3.0186609823291506, 'angle_y': -3.0744558402579947}
```