### PR TITLE
Replace pkg_resources with importlib.metadata

### DIFF
--- a/mqtt_io/modules/__init__.py
+++ b/mqtt_io/modules/__init__.py
@@ -8,8 +8,9 @@ from subprocess import CalledProcessError, check_call
 from types import ModuleType
 from typing import List
 
-# pylint: disable=import-error
-import pkg_resources # type: ignore
+from importlib.metadata import PackageNotFoundError, version
+
+from packaging.requirements import Requirement
 
 from ..exceptions import CannotInstallModuleRequirements
 
@@ -38,10 +39,15 @@ def install_missing_module_requirements(module: ModuleType) -> None:
         _LOG.debug("Module %r has no extra requirements to install.", module)
         return
 
-    pkgs_installed = pkg_resources.WorkingSet()
     pkgs_required = []
     for req in reqs:
-        if pkgs_installed.find(pkg_resources.Requirement.parse(req)) is None:
+        requirement = Requirement(req)
+        try:
+            installed = version(requirement.name)
+        except PackageNotFoundError:
+            pkgs_required.append(req)
+            continue
+        if requirement.specifier and installed not in requirement.specifier:
             pkgs_required.append(req)
 
     if not pkgs_required:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dataclasses = { version = "^0.8", python = ">=3.6,<3.7" }
 aiomqtt = "^2.1.0"
 backoff = "^2.2.1"
 confp = "^0.4.0"
+packaging = ">=23.2"
 # Fix for poetry/docutils related bug
 docutils = "0.18.1"
 
@@ -37,7 +38,7 @@ GitPython = "^3.1.15"
 semver = "^2.13.0"
 docutils = "0.18.1"
 dill = "^0.4.0"
-setuptools = "81.0.0"
+setuptools = "*"
 
 [tool.mypy]
 disable_error_code = ["import-untyped"]


### PR DESCRIPTION
Fixes #441.

`pkg_resources` was removed in setuptools 82.0.0, so mqtt-io fails to import on any environment with a current setuptools:

```
File "mqtt_io/modules/__init__.py", line 12, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

Pinning setuptools below 82, as the development dependencies currently do, is not a way out. Every release that still ships `pkg_resources` is covered by [GHSA-h35f-9h28-mq5c](https://github.com/advisories/GHSA-h35f-9h28-mq5c), so the pin trades an import error for a vulnerability report, and there is no version that is both usable and unaffected:

| setuptools | ships `pkg_resources` | GHSA-h35f-9h28-mq5c |
| --- | --- | --- |
| `< 82` | yes | vulnerable |
| `82.x` | no | vulnerable |
| `>= 83` | no | fixed |

Distributions have moved on regardless. Alpine 3.24 already ships setuptools 82.0.1, so this is not something downstreams can pin their way around either.

`pkg_resources` was used in exactly one place, to work out whether a module's `REQUIREMENTS` are already installed. `importlib.metadata` and `packaging` do that directly, so this swaps the two out and lifts the setuptools pin along with them.

`packaging` is added as a dependency. It is pure Python, already present in most environments, and its `Requirement` parser is the same one pip uses.

**Behaviour is unchanged.** Checked against the installed set:

| Case | Before and after |
| --- | --- |
| Requirement satisfied, bare name | no install attempted |
| Requirement satisfied, with specifier | no install attempted |
| Specifier not satisfied | install attempted |
| Package absent | install attempted |
| No `REQUIREMENTS` | no install attempted |
| Extras syntax, `Pkg[extra]>=1.0` | parsed, no install attempted |

`pylint -d fixme` rates the module 10.00/10 and `mypy --show-error-codes --strict --no-warn-unused-ignores` reports no issues, matching what CI runs.

For context, this came up while updating the Home Assistant community app that packages mqtt-io. It is currently carrying this as a local patch, which I would happily drop.
